### PR TITLE
Add open-source community-health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report a reproducible problem with StockPredictorWithSentiment
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        **Before you continue, please remember:** StockPredictorWithSentiment is an
+        educational tool. It is **NOT financial advice** and must not be used to make
+        real trading or investment decisions.
+
+        Because forecasting is inherently uncertain, **inaccurate forecasts are NOT
+        bugs.** The tool intentionally reports prediction intervals, bounded sentiment,
+        and backtest metrics precisely because point predictions are unreliable. Please
+        do not open issues asking why a forecast "was wrong" or did not match the real
+        market — that is expected behavior, not a defect.
+
+        A bug is something like a crash, a traceback, incorrect math, broken CLI flags,
+        a dashboard rendering error, or behavior that contradicts the documentation.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug, including what you observed.
+      placeholder: Describe the unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Give the exact command line you ran, including the ticker(s), `--start`, and
+        `--end` arguments (and any other flags). Precise reproduction steps are the
+        single most useful thing for diagnosing a bug.
+      placeholder: |
+        e.g.
+        python -m stockpredictor AAPL --start 2024-01-01 --end 2024-06-30
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+      placeholder: Describe what you expected.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit SHA
+      description: Which release version (e.g. 0.2.0) or git commit SHA were you running?
+      placeholder: "0.2.0 or a5e4439"
+    validations:
+      required: false
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python version
+      description: Which Python version were you using?
+      options:
+        - "3.9"
+        - "3.11"
+        - "3.12"
+        - other
+    validations:
+      required: false
+  - type: dropdown
+    id: sentiment-involved
+    attributes:
+      label: Involved sentiment / NewsAPI?
+      description: Did the bug involve the news sentiment feature or NewsAPI?
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Paste any relevant logs or the full traceback. This will be rendered as code.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and this has not already been reported.
+          required: true
+        - label: >
+            This is NOT a security issue. Security vulnerabilities must be reported
+            privately per SECURITY.md, not in a public issue.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/RealMaxPower/StockPredictorWithSentiment/security/advisories/new
+    about: Please report security vulnerabilities privately via a GitHub security advisory, not in a public issue.
+  - name: Questions & discussion
+    url: https://github.com/RealMaxPower/StockPredictorWithSentiment/issues
+    about: For general questions, usage help, or discussion, please use the issue tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest an idea or improvement for StockPredictorWithSentiment
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+
+        StockPredictorWithSentiment is an **educational tool** and is **NOT financial
+        advice.** Please keep proposals aligned with that goal: honest demonstrations of
+        forecasting and sentiment, not trading signals or investment recommendations.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: >
+        What problem are you trying to solve, or what is missing today? Explain the
+        motivation rather than jumping straight to a solution.
+      placeholder: Describe the problem or motivation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change or feature you would like to see.
+      placeholder: Describe your proposed solution.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have considered.
+      placeholder: Describe alternatives.
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Please confirm the following before submitting.
+      options:
+        - label: >
+            I understand this project must remain an honest educational demo. This
+            request does not frame the tool as a trading signal or investment advice,
+            and it preserves the bounded sentiment, prediction intervals, and backtest
+            features.
+          required: true
+        - label: I have searched the existing issues and this has not already been requested.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for contributing to StockPredictorWithSentiment!
+Please fill out the sections below. Keep PRs focused and small where possible.
+-->
+
+## Summary
+
+<!-- What changed and why? Briefly describe the motivation and the approach. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Docs
+- [ ] Refactor
+- [ ] Tests
+- [ ] CI
+
+## Checklist
+
+- [ ] Ran `ruff check .` (lint passes)
+- [ ] Ran `ruff format --check .` (formatting passes)
+- [ ] `mypy stockpredictor` is clean
+- [ ] `pytest --cov=stockpredictor` passes
+- [ ] Tests add NO real network calls (price/news clients are mocked)
+- [ ] Updated `docs/CHANGELOG.md` under **Unreleased** if the change is user-facing
+- [ ] Kept the educational / not-financial-advice framing intact
+- [ ] Kept the bounded sentiment methodology intact
+- [ ] No secrets committed (no `NEWSAPI_KEY`; `.env` stays untracked)
+
+## How tested
+
+<!-- Describe how you verified the change: commands run, scenarios covered, environments. -->
+
+## Related issues
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration for StockPredictorWithSentiment.
+# This complements the pip-audit CI job: pip-audit flags known vulnerabilities
+# in installed dependencies, while Dependabot opens PRs to keep those
+# dependencies (and GitHub Actions) up to date in the first place.
+version: 2
+updates:
+  # Python dependencies (requirements.txt + pyproject.toml).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "pip"
+
+  # GitHub Actions used in CI workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ htmlcov/
 *.swp
 *.swo
 
+# Agent / local tooling state
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "Stock Predictor With Sentiment"
+type: software
+authors:
+  - family-names: Cahill
+    given-names: Marshall
+version: 0.2.0
+license: GPL-3.0-or-later
+repository-code: "https://github.com/RealMaxPower/StockPredictorWithSentiment"
+url: "https://github.com/RealMaxPower/StockPredictorWithSentiment"
+keywords:
+  - stocks
+  - forecasting
+  - sentiment
+  - holt-winters
+  - newsapi
+  - prediction-intervals
+abstract: "An educational tool that forecasts historical stock prices with prediction intervals and contextualizes them with news-sentiment analysis; it is not financial advice."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the project maintainer (@RealMaxPower) via a private GitHub security advisory at https://github.com/RealMaxPower/StockPredictorWithSentiment/security/advisories/new. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Stock Predictor With Sentiment
+
+Thanks for your interest in improving this project! It's a small, educational
+forecasting tool, and contributions of all sizes — bug reports, docs, tests, or
+features — are welcome.
+
+> ⚠️ Please keep the project's framing intact: this is an **educational demo, not
+> financial advice**. Contributions should not present forecasts as trading
+> signals or imply guaranteed returns.
+
+## Getting started
+
+```bash
+git clone https://github.com/RealMaxPower/StockPredictorWithSentiment.git
+cd StockPredictorWithSentiment
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,viz,ml]"   # core + dev tools + plotly + scikit-learn
+```
+
+Optionally set a NewsAPI key to exercise the sentiment path (everything works
+without it — sentiment is simply disabled):
+
+```bash
+cp .env.example .env   # then add your key, or:
+export NEWSAPI_KEY="YOUR_KEY"
+```
+
+## Development workflow
+
+1. Create a branch off `main`: `git checkout -b my-change`.
+2. Make your change, keeping functions small, typed, and readable.
+3. Add or update tests under `tests/` (network is mocked — keep it that way).
+4. Run the full local check suite below; it must pass before you open a PR.
+5. Update [docs/CHANGELOG.md](docs/CHANGELOG.md) under **Unreleased** for any
+   user-facing change.
+6. Open a pull request using the template, explaining **what** and **why**.
+
+## Local checks
+
+These mirror CI (which runs on Python 3.9 / 3.11 / 3.12):
+
+```bash
+ruff check .                 # lint
+ruff format --check .        # formatting
+mypy stockpredictor          # type checking
+pytest -q --cov=stockpredictor   # tests (no network — clients are mocked)
+```
+
+Auto-fix formatting and many lint issues with:
+
+```bash
+ruff format .
+ruff check . --fix
+```
+
+## Guidelines
+
+- **No network in tests.** Inject/patch the price and news clients (see
+  `tests/conftest.py` for fixtures and the existing mocked tests).
+- **Keep the methodology honest.** Bounded sentiment tilt, prediction intervals,
+  and backtesting against baselines are core to the project — don't reintroduce
+  unbounded multipliers or single-point "predictions" that imply false precision.
+- **Don't commit secrets.** `NEWSAPI_KEY` belongs in your local `.env`
+  (gitignored). See [SECURITY.md](SECURITY.md).
+- **Type hints + docstrings** on public functions; `mypy` must stay clean.
+
+## Reporting bugs / requesting features
+
+Use the GitHub issue templates. For security issues, **do not** open a public
+issue — follow [SECURITY.md](SECURITY.md) instead.
+
+## License of contributions
+
+This project is licensed under **GPL-3.0-or-later**. By contributing, you agree
+that your contributions are licensed under the same terms. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -139,3 +139,14 @@ recent Friday (now hardened against a missing/unwritable README and silent no-op
 - **Short history**: tickers with <24 monthly points fall back to a non-seasonal fit;
   <6 points are skipped with a clear error.
 - **No NewsAPI key**: forecasts still run (sentiment is simply disabled).
+
+## License
+
+Copyright © 2025–2026 Marshall Cahill
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the **GNU General Public License v3.0 or later** (`GPL-3.0-or-later`) as
+published by the Free Software Foundation. It is distributed in the hope that it
+will be useful, but **without any warranty**; without even the implied warranty of
+merchantability or fitness for a particular purpose. See the full license text in
+[LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Stock Predictor With Sentiment
 
+[![CI](https://github.com/RealMaxPower/StockPredictorWithSentiment/actions/workflows/ci.yml/badge.svg)](https://github.com/RealMaxPower/StockPredictorWithSentiment/actions/workflows/ci.yml)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Python](https://img.shields.io/badge/python-3.9%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
+
 Forecasts the next 12 months of a stock's price from its history **with prediction
 intervals**, contextualizes it with recent news sentiment, and — crucially —
 **measures whether the forecast actually beats naive baselines** before you trust it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,105 @@
+# Security Policy
+
+`stockpredictor` is an **educational** project that forecasts historical prices and
+contextualizes them with news sentiment. It is **not financial advice**, and it is
+designed to run **locally** (CLI or the Streamlit dashboard) against public data
+sources. It does not host a server, store user accounts, or process payments. Please
+keep that threat model in mind when assessing impact.
+
+We still take security seriously and welcome reports.
+
+## Supported Versions
+
+Security fixes are applied to the latest release and the `main` branch. Older
+tagged versions do not receive backported fixes.
+
+| Version        | Supported |
+| -------------- | --------- |
+| `main` (latest) | ✅        |
+| `0.2.x`        | ✅        |
+| `< 0.2`        | ❌        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's coordinated-disclosure channel:
+
+1. Go to the repository's **Security** tab →
+   **[Report a vulnerability](https://github.com/RealMaxPower/StockPredictorWithSentiment/security/advisories/new)**.
+2. This opens a private advisory visible only to you and the maintainers.
+
+If you cannot use GitHub Security Advisories, email the maintainer privately at
+**<contactme@marshallcahill.com>** with the details. As a last resort, open a regular
+issue that contains **only** "I would like to report a security issue, please advise
+on a private channel" — with no technical detail — and a maintainer will follow up.
+
+When reporting, please include where practical:
+
+- A description of the issue and its impact.
+- Steps to reproduce (a ticker string, input, config, or command line).
+- The affected file/function and version or commit SHA.
+- Any suggested remediation.
+
+### What to expect
+
+- **Acknowledgement:** within 5 business days.
+- **Assessment & triage:** we aim to confirm or dismiss within 10 business days.
+- **Fix & disclosure:** coordinated with you. We prefer to publish a fix before
+  public disclosure and will credit you in the advisory unless you ask otherwise.
+
+## Scope
+
+**In scope** — the code in this repository:
+
+- The `stockpredictor` package (`data`, `forecast`, `sentiment`, `news`,
+  `pipeline`, `store`, `plotting`, `cli`, `sanitize`).
+- The Streamlit dashboard ([`app.py`](app.py)).
+- The CLI entry points and the SQLite store ([`store.py`](stockpredictor/store.py)).
+
+**Out of scope:**
+
+- Vulnerabilities in third-party data providers (NewsAPI, Yahoo Finance / `yfinance`)
+  or any external service this project merely calls.
+- Advisories in transitive dependencies that have no project-level remedy on our
+  supported Python versions. The CI `audit` job in
+  [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `pip-audit` and reports
+  these on every build. If you find a transitive advisory that *is* fixable for us, a
+  report or PR bumping the floor is welcome.
+- Misuse of your own credentials (see **Secrets** below).
+- The forecasts themselves. Outputs are illustrative and explicitly **not financial
+  advice**; inaccurate predictions are not security issues.
+
+## Secrets
+
+- The only secret this project uses is an optional `NEWSAPI_KEY`. It is read from the
+  environment (or `.streamlit/secrets.toml` for the dashboard) — never hard-coded.
+- `.env` and `.env.local` are git-ignored; copy [`.env.example`](.env.example) to
+  `.env` and keep it out of version control. **Never commit an API key.**
+- If you accidentally commit a key, rotate it at <https://newsapi.org> immediately;
+  removing it from history alone is not sufficient once it has been pushed.
+
+## Security posture
+
+The project applies defense-in-depth appropriate to a local tool:
+
+- **Input validation** — user-supplied ticker symbols are validated against a strict
+  allow-list before they reach the filesystem, news queries, or the database
+  ([`sanitize.py`](stockpredictor/sanitize.py)), preventing path traversal.
+- **Output safety** — untrusted news titles and URLs rendered in the dashboard are
+  markdown-escaped and restricted to `http(s)` links, blocking link/script injection.
+- **Parameterized SQL** — every query in the SQLite store uses bound parameters; no
+  string interpolation into SQL.
+- **Dependency auditing** — `pip-audit` runs in CI on every push and pull request,
+  surfacing known advisories in the dependency tree.
+
+If you are running the dashboard somewhere other than your own machine, treat it as
+an unauthenticated, internet-facing app: put it behind authentication and a reverse
+proxy, since it issues outbound API calls on behalf of whoever can reach it.
+
+## A note for security researchers
+
+Because this is a local, single-user educational tool, please weigh real-world
+impact before reporting. Findings that require an attacker to already control the
+machine, the command line, or the database path are generally low severity — but if
+you are unsure, report it and let us assess. We would rather hear about it.

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import streamlit as st
 
 from stockpredictor import config, news, plotting
 from stockpredictor.pipeline import run_ticker
+from stockpredictor.sanitize import escape_markdown, safe_url, sanitize_ticker
 
 PRESETS = {
     "Magnificent Seven": "AAPL,MSFT,GOOGL,AMZN,NVDA,META,TSLA",
@@ -119,10 +120,13 @@ def _render_result(ticker: str, result, cfg) -> None:
         for art in result.articles:
             score = art.get("sentiment", 0.0)
             emoji = "🟢" if score > 0.05 else "🔴" if score < -0.05 else "⚪"
-            st.markdown(
-                f"{emoji} **[{art['title']}]({art.get('url', '#')})** "
-                f"— *{art.get('source') or 'unknown'}* ({score:+.2f})"
-            )
+            # News titles/URLs are untrusted: escape markdown and allow only
+            # http(s) links so a headline can't break out or inject a script URL.
+            title = escape_markdown(art.get("title") or "(untitled)")
+            source = escape_markdown(art.get("source") or "unknown")
+            url = safe_url(art.get("url"))
+            label = f"[{title}]({url})" if url else title
+            st.markdown(f"{emoji} **{label}** — *{source}* ({score:+.2f})")
 
 
 def _comparison_table(results: dict) -> pd.DataFrame:
@@ -174,9 +178,19 @@ def main() -> None:
         st.write("Set parameters in the sidebar and click **Run forecast**.")
         return
 
-    tickers = [t.strip().upper() for t in tickers_raw.split(",") if t.strip()]
+    tickers: list[str] = []
+    invalid: list[str] = []
+    for raw in tickers_raw.split(","):
+        if not raw.strip():
+            continue
+        try:
+            tickers.append(sanitize_ticker(raw))
+        except ValueError:
+            invalid.append(raw.strip())
+    if invalid:
+        st.warning("Ignored invalid ticker(s): " + ", ".join(invalid))
     if not tickers:
-        st.warning("Enter at least one ticker.")
+        st.warning("Enter at least one valid ticker.")
         return
 
     results: dict = {}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+_Nothing yet._
+
+### Changed
+
+_Nothing yet._
+
+### Fixed
+
+_Nothing yet._
+
+## [0.2.0]
+
+### Added
+
+- 80% and 95% Monte-Carlo prediction intervals around every forecast.
+- Baseline models plus a walk-forward, rolling-origin backtest reporting MAE, RMSE,
+  MAPE, MASE, and directional accuracy.
+- The `stockpredictor` package with a mocked-network pytest suite, ruff (lint +
+  format), mypy, GitHub Actions CI, `pyproject.toml`, structured logging, and SQLite
+  caching.
+- Streamlit dashboard and interactive Plotly HTML output.
+- Optional SARIMAX and gradient-boosting models, compared on the same backtest.
+- Input sanitization: ticker allow-list validation and markdown/link output escaping.
+
+### Changed
+
+- News sentiment is now a bounded, decaying, confidence-shrunk **tilt** (capped at
+  roughly ±5% in month 1) instead of multiplying the entire forecast by
+  `(1 + sentiment)`.
+- `--no-sentiment` disables the sentiment tilt entirely.
+- The news window is anchored to `--end` (not "now"), with a loud free-tier 30-day
+  warning when the requested window exceeds the NewsAPI free-tier limit.
+- Forecasting now uses adjusted close prices.
+
+### Fixed
+
+- Splits and dividends no longer read as price crashes, thanks to using adjusted close.
+- Seasonal fitting now requires at least 24 months of data, with a non-seasonal
+  fallback; series shorter than 6 months are skipped with a clear error.
+
+## [0.1.0]
+
+- Initial single-script version that multiplied the forecast by `(1 + sentiment)` with no backtest.
+
+[Unreleased]: https://github.com/RealMaxPower/StockPredictorWithSentiment/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/RealMaxPower/StockPredictorWithSentiment/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/RealMaxPower/StockPredictorWithSentiment/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Historical price forecasting with prediction intervals and news-s
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "GPL-3.0-or-later" }
-authors = [{ name = "RealMaxPower" }]
+authors = [{ name = "Marshall Cahill", email = "contactme@marshallcahill.com" }]
 keywords = ["stocks", "forecasting", "sentiment", "holt-winters", "newsapi"]
 
 dependencies = [

--- a/stockpredictor/cli.py
+++ b/stockpredictor/cli.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime
 
 from . import config, data, forecast, pipeline
+from .sanitize import sanitize_ticker
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -91,8 +92,17 @@ def main(argv: list | None = None) -> int:
     args = _build_parser().parse_args(argv)
     logger = config.setup_logging(args.log_level)
 
+    tickers: list[str] = []
+    for raw in args.tickers.split(","):
+        if not raw.strip():
+            continue
+        try:
+            tickers.append(sanitize_ticker(raw))
+        except ValueError as exc:
+            logger.error("%s", exc)
+
     cfg = config.AppConfig(
-        tickers=[t.strip().upper() for t in args.tickers.split(",") if t.strip()],
+        tickers=tickers,
         start=args.start,
         end=args.end,
         outdir=args.outdir,

--- a/stockpredictor/pipeline.py
+++ b/stockpredictor/pipeline.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from . import config, data, forecast, news, sentiment
 from .forecast import ForecastResult
+from .sanitize import sanitize_ticker
 from .sentiment import Scorer, SentimentResult
 
 logger = logging.getLogger("stockpredictor.pipeline")
@@ -45,7 +46,8 @@ def run_ticker(
     compare_models: bool = False,
 ) -> TickerResult:
     """Fetch, forecast (with intervals + backtest), score news, and apply the tilt."""
-    ticker = ticker.upper()
+    # Validate before the symbol becomes a file name in persist_outputs/plotting.
+    ticker = sanitize_ticker(ticker)
     df = data.fetch_prices(ticker, cfg.start, cfg.end, downloader=price_downloader)
     monthly, warns = data.to_monthly(df, ticker)
 

--- a/stockpredictor/sanitize.py
+++ b/stockpredictor/sanitize.py
@@ -1,0 +1,62 @@
+"""
+Input-hardening helpers for untrusted strings. Centralized so the CLI, the
+dashboard, and the pipeline all validate identically.
+
+Two concerns:
+
+- ``sanitize_ticker`` stops a user-supplied symbol from escaping an output
+  directory when it is interpolated into a file name (path traversal): a ticker
+  is the key for ``{ticker}_forecasts.png`` etc., so ``../../x`` must never get
+  that far.
+- ``escape_markdown`` / ``safe_url`` keep untrusted news titles and links from
+  breaking out of the Streamlit markdown they are rendered into.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Real symbols use letters, digits, dots, hyphens, and (for indices/futures/forex)
+# "^" and "=": AAPL, BRK.B, RDS-A, RELIANCE.NS, ^GSPC, GC=F, EURUSD=X. The first
+# character must be alphanumeric or "^", so a value can never start with "." or
+# "-" — in particular ".." and "/.." are rejected. Crucially the class excludes
+# the path separators "/" and "\", so a symbol can never escape its output dir
+# when interpolated into a file name.
+_TICKER_RE = re.compile(r"^[A-Z0-9^][A-Z0-9.\-^=]{0,14}$")
+
+# Markdown delimiters that could let untrusted text break out of a link label,
+# inject emphasis, or smuggle an image/link of its own.
+_MD_SPECIAL = re.compile(r"([\\`*_{}\[\]()#+!~|<>])")
+
+# Characters that must not appear in a markdown link target, since they would
+# close the "(...)" or otherwise change where the link points.
+_URL_FORBIDDEN = set("<> \t\r\n\"'()")
+
+
+def sanitize_ticker(raw: str) -> str:
+    """Normalize and validate a ticker symbol; raise ``ValueError`` if invalid."""
+    ticker = raw.strip().upper()
+    if not _TICKER_RE.match(ticker):
+        raise ValueError(f"Invalid ticker symbol: {raw!r}")
+    return ticker
+
+
+def escape_markdown(text: str | None) -> str:
+    """Escape markdown control characters so untrusted text renders literally."""
+    return _MD_SPECIAL.sub(r"\\\1", str(text or ""))
+
+
+def safe_url(url: str | None) -> str | None:
+    """
+    Return ``url`` only if it is a plain http(s) link safe to drop into a
+    markdown target, else ``None``. Rejects ``javascript:``/``data:`` schemes
+    and anything containing characters that could break out of the link.
+    """
+    if not url:
+        return None
+    candidate = str(url).strip()
+    if not candidate.lower().startswith(("http://", "https://")):
+        return None
+    if any(ch in candidate for ch in _URL_FORBIDDEN):
+        return None
+    return candidate

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,89 @@
+"""Input-hardening tests: ticker validation (path-traversal) and markdown safety."""
+
+from __future__ import annotations
+
+import pytest
+
+from stockpredictor import pipeline
+from stockpredictor.sanitize import escape_markdown, safe_url, sanitize_ticker
+
+
+class TestSanitizeTicker:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("aapl", "AAPL"),
+            (" msft ", "MSFT"),
+            ("brk.b", "BRK.B"),  # dotted class shares are valid
+            ("rds-a", "RDS-A"),  # hyphenated shares are valid
+            ("reliance.ns", "RELIANCE.NS"),  # international suffix
+            ("^gspc", "^GSPC"),  # index symbol
+            ("gc=f", "GC=F"),  # futures symbol
+            ("V", "V"),
+        ],
+    )
+    def test_normalizes_valid_symbols(self, raw, expected):
+        assert sanitize_ticker(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "../../etc/passwd",  # path traversal
+            "..",
+            "a/b",  # path separator
+            r"a\b",
+            ".env",  # leading dot
+            "-rf",  # leading hyphen
+            "AAPL_NEWS",  # underscore not allowed
+            "a b",  # whitespace inside
+            "ABCDEFGHIJKLMNOP",  # 16 valid chars, over the 15-char bound
+            "",
+            "   ",
+        ],
+    )
+    def test_rejects_invalid_symbols(self, raw):
+        with pytest.raises(ValueError):
+            sanitize_ticker(raw)
+
+    def test_run_ticker_rejects_path_traversal(self, cfg):
+        # The pipeline core must reject before the symbol becomes a file name.
+        with pytest.raises(ValueError):
+            pipeline.run_ticker("../../tmp/evil", cfg)
+
+
+def test_escape_markdown_neutralizes_link_breakout():
+    evil = "Buy now](http://evil.test) ![pwn](http://evil.test/x"
+    out = escape_markdown(evil)
+    assert "](" not in out  # brackets and parens are escaped
+    assert r"\]" in out and r"\(" in out
+
+
+def test_escape_markdown_handles_none():
+    assert escape_markdown(None) == ""
+
+
+class TestSafeUrl:
+    @pytest.mark.parametrize(
+        "url",
+        ["https://example.com/a", "http://news.test/path?q=1&x=2"],
+    )
+    def test_allows_clean_http(self, url):
+        assert safe_url(url) == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "ftp://example.com/x",
+            "https://e.test/a b",  # whitespace
+            "https://e.test/a)b",  # paren would close the link
+            "https://e.test/<x>",  # angle brackets
+            "//example.com",  # scheme-relative
+            None,
+            "",
+            "#",
+        ],
+    )
+    def test_rejects_unsafe(self, url):
+        assert safe_url(url) is None


### PR DESCRIPTION
## Summary

Adds the community-health files that complete the repo for open source. All content is tailored to this project — GPL-3.0-or-later, `stockpredictor` 0.2.0, Python 3.9/3.11/3.12, and the ruff/mypy/pytest/pip-audit CI — and keeps the "educational demo, not financial advice" framing intact.

| File | What |
|------|------|
| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.1; violations reported privately to `@RealMaxPower` via GitHub security advisory (no personal email published) |
| `CONTRIBUTING.md` | Setup, local checks mirroring CI, PR workflow |
| `CITATION.cff` | Citation File Format 1.2.0 |
| `docs/CHANGELOG.md` | Keep a Changelog; 0.2.0 + 0.1.0 history |
| `.github/ISSUE_TEMPLATE/` | Bug-report + feature-request issue forms + `config.yml` |
| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist |
| `.github/dependabot.yml` | Weekly `pip` + `github-actions` updates (complements the pip-audit CI job) |
| `README.md` | CI + GPLv3 + Python-version badges under the title |
| `.gitignore` | Ignore local agent tooling state (`.claude/`) |

## Notes
- `SECURITY.md` already exists (committed separately) and is **not** touched here.
- No secrets: scanned the diff — no API keys/tokens, no `NEWSAPI_KEY` values, and the maintainer's personal Gmail is absent. `.env`/`.env.local` remain gitignored.
- All YAML/CFF files parse cleanly; README's heading is unchanged apart from the three added badge lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)