### PR TITLE
ci: restrict GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Restrict the default GITHUB_TOKEN to read-only; no job here writes to the repo.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What

Adds a top-level read-only `permissions` block to the CI workflow:

```yaml
permissions:
  contents: read
```

## Why

Resolves the two open code scanning alerts from the `actions/missing-workflow-permissions` CodeQL rule (one per job — `test` and `audit`). Without an explicit block, `GITHUB_TOKEN` defaults to broad write scopes.

Neither CI job writes to the repository, comments on PRs, or publishes packages — they only check out code and run tests/lint/audit. So `contents: read` is the minimal sufficient scope, and a single top-level block applies to both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)