### PR TITLE
build: drop unused kaleido from the viz extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-viz = ["plotly>=5.18", "kaleido>=0.2.1"]
+viz = ["plotly>=5.18"]
 app = ["streamlit>=1.30", "plotly>=5.18"]
 ml = ["scikit-learn>=1.6.1"]
 finbert = ["transformers>=4.57.6", "torch>=2.0"]


### PR DESCRIPTION
## What

Removes `kaleido` from the `viz` optional-dependencies extra in `pyproject.toml`.

## Why

`kaleido` is only used for **static** image export through plotly's `write_image()` / `to_image()`. This codebase builds **interactive** plotly figures (`graph_objects` in [stockpredictor/plotting.py](stockpredictor/plotting.py)) and never exports static images — `grep` for `kaleido`/`write_image`/`to_image` across the repo returns nothing. So it was a declared-but-unused dependency.

Dropping it also avoids the kaleido **1.x** rewrite (a major breaking change that requires a separately-installed Chrome/Chromium and a `plotly_get_chrome` step). If static export is ever needed, re-add `kaleido` and document that setup.

## Supersedes

Closes out Dependabot PR #15 (`kaleido >=0.2.1 -> >=1.3.0`), which is moot once the dependency is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)