### PR TITLE
chore(security): add ruff flake8-bandit (S) lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,13 @@ line-length = 100
 target-version = "py39"
 
 [tool.ruff.lint]
-# E/W pycodestyle, F pyflakes, I isort, B bugbear, UP pyupgrade
-select = ["E", "W", "F", "I", "B", "UP"]
+# E/W pycodestyle, F pyflakes, I isort, B bugbear, UP pyupgrade, S flake8-bandit
+select = ["E", "W", "F", "I", "B", "UP", "S"]
 ignore = ["E501"]  # line length handled by the formatter
+
+[tool.ruff.lint.per-file-ignores]
+# Tests legitimately use assert; S101 is expected there, not a security smell.
+"tests/**" = ["S101"]
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
## What & why

I reviewed the repo's security/CI posture for gaps. **It's already strong** — the genuinely additive change is small.

### Already in place (no action needed)
- CodeQL (default setup, `python` + `actions`), Dependabot (pip + actions, weekly, well-configured), pip-audit in CI
- Secret scanning **+ push protection** (already enabled), Dependabot security updates / automated fixes
- Read-only `GITHUB_TOKEN`, ticker input sanitization, parameterized SQL, markdown/URL output escaping

### This PR
- **ruff `S` (flake8-bandit)** — a static security lint layer that complements CodeQL (flags `shell=True`, insecure tempfiles, unsafe deserialization, etc.) at lint time. `S101` (assert) ignored under `tests/`. **No findings** in the package today, so it's a regression guardrail.

### Done outside this diff (repo settings, via API)
- **CodeQL query suite upgraded `default` → `extended`** — broader security coverage. Verified `query_suite: extended`.

### Deliberately NOT done (gold-plating for a local, single-user educational tool)
- Separate bandit job (redundant with CodeQL + ruff `S`), OpenSSF Scorecard, action SHA-pinning (tags + Dependabot suffice), making pip-audit blocking (disputed advisories would cause noise), branch protection rules.

## Note
My initial review flagged a "dependabot EOF bug" and "push protection disabled" — both were **wrong on inspection** (dependabot.yml is valid; push protection was already on). No changes made there.

## Verification
`ruff check .` (with `S`), `ruff format --check .`, `mypy stockpredictor` — all clean; `pytest -q` — 79 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)