### PR TITLE
security: scrub untrusted values before logging (CWE-117)

### DIFF
--- a/stockpredictor/data.py
+++ b/stockpredictor/data.py
@@ -14,6 +14,8 @@ from typing import Callable
 
 import pandas as pd
 
+from .sanitize import scrub
+
 logger = logging.getLogger("stockpredictor.data")
 
 # Default downloader is yfinance; injected in tests.
@@ -97,6 +99,7 @@ def to_monthly(df: pd.DataFrame, ticker: str, agg: str = "last") -> tuple[pd.Ser
             f"{len(suspect)} day(s) move > {_SUSPECT_MONTHLY_MOVE:.0%} — "
             "possible unadjusted split/dividend"
         )
+    log_ticker = scrub(ticker)
     for w in warns:
-        logger.warning("%s: %s", ticker, w)
+        logger.warning("%s: %s", log_ticker, w)
     return monthly, warns

--- a/stockpredictor/news.py
+++ b/stockpredictor/news.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 from . import config
+from .sanitize import scrub
 
 logger = logging.getLogger("stockpredictor.news")
 
@@ -117,6 +118,8 @@ def fetch_articles(
     """
     cfg = cfg or config.AppConfig()
     query = build_query(ticker)
+    # Untrusted ticker/query are echoed in log lines below; scrub once for logging.
+    log_ticker, log_query = scrub(ticker), scrub(query)
     win_from, win_to = _news_window(end_date, cfg.news_lookback_days)
 
     days_old = (datetime.now(timezone.utc).date() - datetime.fromisoformat(win_to).date()).days
@@ -124,20 +127,20 @@ def fetch_articles(
         logger.warning(
             "%s: requested news window ends %s (%d days ago) — NewsAPI free tier "
             "(~%d days) likely cannot serve it; will degrade to no-news.",
-            ticker,
+            log_ticker,
             win_to,
             days_old,
             _FREE_TIER_DAYS,
         )
 
-    logger.info("%s: news query %s, window %s..%s", ticker, query, win_from, win_to)
+    logger.info("%s: news query %s, window %s..%s", log_ticker, log_query, win_from, win_to)
     tried_without_dates = False
 
     for attempt in range(cfg.max_retries):
         try:
             if attempt > 0:
                 wait = 2**attempt
-                logger.warning("%s: retry %d in %ds", ticker, attempt, wait)
+                logger.warning("%s: retry %d in %ds", log_ticker, attempt, wait)
                 sleeper(wait)
 
             kwargs = {
@@ -154,7 +157,7 @@ def fetch_articles(
 
             if resp.get("code"):
                 code, msg = resp.get("code", ""), resp.get("message", "")
-                logger.warning("%s: NewsAPI error (%s): %s", ticker, code, msg)
+                logger.warning("%s: NewsAPI error (%s): %s", log_ticker, scrub(code), scrub(msg))
                 if (
                     code == "parameterInvalid"
                     and "far in the past" in msg
@@ -174,19 +177,19 @@ def fetch_articles(
                 if attempt < cfg.max_retries - 1:
                     continue
             else:
-                logger.info("%s: fetched %d articles", ticker, len(articles))
+                logger.info("%s: fetched %d articles", log_ticker, len(articles))
                 return [_normalize(a) for a in articles]
 
         except Exception as exc:  # noqa: BLE001 - networking is best-effort
             msg = str(exc)
-            logger.warning("%s: attempt %d failed: %s", ticker, attempt + 1, msg)
+            logger.warning("%s: attempt %d failed: %s", log_ticker, attempt + 1, scrub(msg))
             if (
                 "parameterInvalid" in msg or "too far in the past" in msg
             ) and not tried_without_dates:
                 tried_without_dates = True
                 continue
             if attempt == cfg.max_retries - 1:
-                logger.error("%s: all news attempts failed; using no news", ticker)
+                logger.error("%s: all news attempts failed; using no news", log_ticker)
                 return []
 
     return []

--- a/stockpredictor/sanitize.py
+++ b/stockpredictor/sanitize.py
@@ -32,6 +32,24 @@ _MD_SPECIAL = re.compile(r"([\\`*_{}\[\]()#+!~|<>])")
 # close the "(...)" or otherwise change where the link points.
 _URL_FORBIDDEN = set("<> \t\r\n\"'()")
 
+# ASCII control characters (C0 range plus DEL): a CR/LF lets untrusted input
+# forge or split extra log lines, and other control codes can smuggle terminal
+# escape sequences into a log viewer ("log injection", CWE-117).
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def scrub(value: object) -> str:
+    """
+    Flatten ``value`` into a single line that is safe to write to a log.
+
+    Strips CR/LF and other control characters so an attacker-controlled string
+    (e.g. a ticker from the CLI or dashboard) cannot inject newlines and forge
+    additional log entries. The explicit ``\\r``/``\\n`` replacements keep the
+    sanitization recognizable to static analysis.
+    """
+    cleaned = _CONTROL_CHARS.sub(" ", str(value))
+    return cleaned.replace("\r", " ").replace("\n", " ")
+
 
 def sanitize_ticker(raw: str) -> str:
     """Normalize and validate a ticker symbol; raise ``ValueError`` if invalid."""

--- a/stockpredictor/store.py
+++ b/stockpredictor/store.py
@@ -14,6 +14,8 @@ from datetime import date, datetime, timedelta
 
 import pandas as pd
 
+from .sanitize import scrub
+
 logger = logging.getLogger("stockpredictor.store")
 
 _SCHEMA = """
@@ -110,7 +112,7 @@ class Store:
             "Close": [r["close"] for r in rows],
             "Volume": [r["volume"] for r in rows],
         }
-        logger.info("%s: price cache hit (%d rows)", ticker, len(rows))
+        logger.info("%s: price cache hit (%d rows)", scrub(ticker), len(rows))
         return pd.DataFrame(data, index=idx)
 
     # --- run history ---------------------------------------------------------
@@ -180,7 +182,7 @@ def make_cached_downloader(store: Store, base_downloader, ttl_days: int = 1):
         try:
             store.upsert_prices(ticker, df)
         except Exception as exc:  # noqa: BLE001 - caching must never break a run
-            logger.warning("%s: could not cache prices: %s", ticker, exc)
+            logger.warning("%s: could not cache prices: %s", scrub(ticker), scrub(exc))
         return df
 
     return _dl

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from stockpredictor import pipeline
-from stockpredictor.sanitize import escape_markdown, safe_url, sanitize_ticker
+from stockpredictor.sanitize import escape_markdown, safe_url, sanitize_ticker, scrub
 
 
 class TestSanitizeTicker:
@@ -49,6 +49,28 @@ class TestSanitizeTicker:
         # The pipeline core must reject before the symbol becomes a file name.
         with pytest.raises(ValueError):
             pipeline.run_ticker("../../tmp/evil", cfg)
+
+
+class TestScrub:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "AAPL\nADMIN: forged entry",  # newline forging a second log line
+            "AAPL\r\nADMIN",  # CRLF
+            "AAPL\x1b[31mred",  # terminal escape sequence
+            "AAPL\x00\x07",  # NUL and BEL
+        ],
+    )
+    def test_removes_control_chars(self, raw):
+        out = scrub(raw)
+        assert "\n" not in out and "\r" not in out
+        assert not any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in out)
+
+    def test_passes_through_plain_text(self):
+        assert scrub("AAPL: fetched 5 articles") == "AAPL: fetched 5 articles"
+
+    def test_coerces_non_str(self):
+        assert scrub(42) == "42"
 
 
 def test_escape_markdown_neutralizes_link_breakout():


### PR DESCRIPTION
## What

Resolves the **10 open `py/log-injection` code scanning alerts** (CWE-117, medium severity) in `news.py`, `data.py`, and `store.py`.

Adds a `scrub()` helper to `sanitize.py` that flattens a value to a single safe-to-log line (strips CR/LF and other ASCII control characters), and applies it to the untrusted values at every flagged log site.

## Why

A user-provided `ticker` (from the CLI or dashboard) — and the `query`/error strings derived from it or returned by the NewsAPI client — flowed into `logger` calls unsanitized. An attacker could embed:
- **CR/LF** to forge or split log entries (e.g. inject a fake `ADMIN: ...` line), or
- **terminal escape sequences** to tamper with a log viewer.

`run_ticker` already validates tickers via `sanitize_ticker`, but these functions are public and reachable directly, so the defense belongs at the log sites. The static analyzer also treats their `ticker` parameter as untrusted regardless of caller.

## Scope of change

- Only the **logged copies** are scrubbed — the real `ticker`/`query`/error values are untouched, so control flow (retry/fallback decisions) and outbound NewsAPI calls behave exactly as before.
- Alerts covered: `data.py:101`, `news.py:127/133/140/157/177/182/189`, `store.py:183` (+ `store.py:113` scrubbed for consistency).

## Tests

- New `TestScrub` covering newline/CRLF forging, terminal escapes, NUL/BEL, plain-text passthrough, and non-str coercion.
- Full suite, `ruff`, `ruff format`, and `mypy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)