### PR TITLE
feat(sim): Phase 1 — cost-aware paper-trading simulator foundation

### DIFF
--- a/stockpredictor/config.py
+++ b/stockpredictor/config.py
@@ -46,7 +46,35 @@ INTER_TICKER_SLEEP = 1.0
 # --- Plot defaults -----------------------------------------------------------
 PLOT_DPI = 150
 
+# --- Simulation / trading-cost defaults --------------------------------------
+# Paper-trading only: these drive a *simulated* book, never a real order.
+# Defaults are deliberately conservative (retail-realistic) so a backtest is not
+# flattered by free, frictionless trading. Costs are ALWAYS applied — there is no
+# gross-of-cost headline. See ``costs.py`` and ``portfolio.py``.
+PERIODS_PER_YEAR = 12  # monthly rebalance cadence, matching the forecast
+COMMISSION_BPS = 1.0  # broker commission per trade leg (bps of notional)
+SPREAD_BPS = 5.0  # full bid/ask spread (bps); a trade crosses half of it
+SLIPPAGE_BPS = 5.0  # market-impact / slippage (bps of notional)
+FIXED_FEE = 0.0  # optional flat fee per (non-zero) trade, in currency
+RF_ANNUAL = 0.04  # risk-free rate; a constant default emits a warning
+MAX_WEIGHT = 1.0  # long-only, no leverage: weight is clipped to [0, 1]
+TARGET_VOL = 0.10  # annualized volatility target for vol-sizing
+KELLY_FRACTION = 0.25  # fractional Kelly (full Kelly is never the default)
+CONFIDENCE_FLOOR = 0.0  # minimum signal confidence to take any position
+SIM_WARMUP_MONTHS = MIN_MONTHS_FOR_ANY_FIT  # history needed before the first trade
+HOLDOUT_PERIODS = 12  # final out-of-sample slice, touched exactly once
+
 DISCLAIMER = "Educational demo — not financial advice."
+
+
+def periodic_rate(annual_rate: float, periods_per_year: int = PERIODS_PER_YEAR) -> float:
+    """Convert an annual rate to the equivalent compounded per-period rate.
+
+    Shared by the simulator (cash/risk-free leg), the strategy threshold (excess
+    over RF), and the evaluation metrics so the risk-free convention never
+    diverges between them.
+    """
+    return (1.0 + annual_rate) ** (1.0 / periods_per_year) - 1.0
 
 
 @dataclass
@@ -81,6 +109,21 @@ class AppConfig:
 
     use_cache: bool = True
     db_path: str = "stockpredictor.db"
+
+    # --- Simulated betting / position-sizing layer ---------------------------
+    # Trading costs (bps of traded notional) — always applied in the simulator.
+    commission_bps: float = COMMISSION_BPS
+    spread_bps: float = SPREAD_BPS
+    slippage_bps: float = SLIPPAGE_BPS
+    fixed_fee: float = FIXED_FEE
+    # Risk-free, position limits, and sizing.
+    rf_annual: float = RF_ANNUAL
+    max_weight: float = MAX_WEIGHT
+    target_vol: float = TARGET_VOL
+    kelly_fraction: float = KELLY_FRACTION
+    confidence_floor: float = CONFIDENCE_FLOOR
+    sizing_method: str = "vol"  # "vol" (volatility targeting) | "kelly"
+    holdout_periods: int = HOLDOUT_PERIODS
 
 
 def setup_logging(level: str = "INFO") -> logging.Logger:

--- a/stockpredictor/costs.py
+++ b/stockpredictor/costs.py
@@ -1,0 +1,76 @@
+"""
+Transaction-cost model for the simulated betting layer.
+
+Pure and deterministic: no network, no I/O, no global state. Every simulated
+trade pays a cost here, so the backtest is never flattered by free, frictionless
+trading. There is deliberately no "gross of costs" path — a cost-free curve may
+exist only as a clearly-labeled diagnostic elsewhere, never as a headline.
+
+The model is intentionally simple and explicit (§5 of the execution brief):
+
+    cost = |trade_notional| * (commission_bps + spread_bps/2 + slippage_bps) / 1e4
+           + fixed_fee   (only when something is actually traded)
+
+A trade crosses *half* the quoted bid/ask spread (you transact at the mid plus
+half-spread), hence ``spread_bps / 2``; commission and slippage apply to the full
+traded notional. Cost scales linearly with traded notional and therefore with
+turnover, which is what makes the cost-monotonicity guarantee hold.
+
+⚠ Educational demo — not financial advice. This moves simulated numbers only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from . import config
+
+
+@dataclass(frozen=True)
+class TradingCosts:
+    """Per-notional transaction costs, all expressed in basis points (1e-4).
+
+    ``fixed_fee`` is a flat per-trade charge in currency units, applied once per
+    non-zero trade (a zero-notional rebalance pays nothing).
+    """
+
+    commission_bps: float = 1.0
+    spread_bps: float = 5.0
+    slippage_bps: float = 5.0
+    fixed_fee: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("commission_bps", "spread_bps", "slippage_bps", "fixed_fee"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+    @property
+    def per_notional_bps(self) -> float:
+        """Total variable cost in bps charged on each unit of traded notional."""
+        return self.commission_bps + self.spread_bps / 2.0 + self.slippage_bps
+
+    @classmethod
+    def from_config(cls, cfg: config.AppConfig) -> TradingCosts:
+        """Build a cost model from the shared ``AppConfig`` (all flags live there)."""
+        return cls(
+            commission_bps=cfg.commission_bps,
+            spread_bps=cfg.spread_bps,
+            slippage_bps=cfg.slippage_bps,
+            fixed_fee=cfg.fixed_fee,
+        )
+
+
+def apply_costs(trade_notional: float, costs: TradingCosts) -> float:
+    """Cost in currency of trading ``trade_notional`` (signed or unsigned).
+
+    Returns ``0.0`` for a zero-notional trade (no fixed fee on a no-op rebalance).
+    Otherwise the variable per-notional cost plus any fixed per-trade fee. Always
+    non-negative and monotonically increasing in ``|trade_notional|``.
+    """
+    notional = abs(float(trade_notional))
+    if notional == 0.0:
+        return 0.0
+    return notional * costs.per_notional_bps / 1e4 + costs.fixed_fee

--- a/stockpredictor/plotting.py
+++ b/stockpredictor/plotting.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from . import config
 from .forecast import ForecastResult
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .portfolio import SimulationResult
 
 logger = logging.getLogger("stockpredictor.plotting")
 
@@ -83,6 +87,116 @@ def plot_forecast(
     plt.close(fig)
     logger.info("%s: saved plot %s", ticker, path)
     return path
+
+
+def plot_equity_curve(
+    result: SimulationResult,
+    ticker: str,
+    out_dir: str,
+    cfg: config.AppConfig,
+) -> str:
+    """Save a PNG overlaying strategy vs buy-and-hold vs risk-free equity curves.
+
+    ``result`` is a ``portfolio.SimulationResult``; imported lazily to avoid a
+    hard dependency from ``plotting`` onto the simulation layer.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(
+        result.equity.index,
+        result.equity.values,
+        label="Strategy (after costs)",
+        color="#1f77b4",
+        linewidth=2,
+    )
+    ax.plot(
+        result.benchmark_bh.index,
+        result.benchmark_bh.values,
+        label="Buy & hold",
+        color="#ff7f0e",
+    )
+    ax.plot(
+        result.benchmark_rf.index,
+        result.benchmark_rf.values,
+        label=f"Risk-free ({result.rf_annual:.1%})",
+        color="#2ca02c",
+        linestyle="--",
+    )
+    title = f"{ticker}: simulated equity curve (out-of-sample, after costs)"
+    if result.peek:
+        title += f" ⚠ LEAKED peek={result.peek}"
+    ax.set_title(title)
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Equity (start = 1.0)")
+    ax.legend(loc="upper left", fontsize=8)
+    fig.text(
+        0.99,
+        0.01,
+        config.DISCLAIMER,
+        ha="right",
+        va="bottom",
+        fontsize=7,
+        color="gray",
+        style="italic",
+    )
+    fig.tight_layout()
+
+    path = os.path.join(out_dir, f"{ticker}_SIM_equity.png")
+    fig.savefig(path, dpi=cfg.plot_dpi)
+    plt.close(fig)
+    logger.info("%s: saved equity curve %s", ticker, path)
+    return path
+
+
+def write_equity_html(result: SimulationResult, ticker: str, out_dir: str) -> str | None:
+    """Write a self-contained interactive Plotly equity overlay. No-op if no plotly."""
+    try:
+        fig = build_equity_figure(result, ticker)
+    except ImportError:
+        logger.info("%s: plotly not installed; skipping equity HTML", ticker)
+        return None
+    path = os.path.join(out_dir, f"{ticker}_SIM_equity.html")
+    fig.write_html(path, include_plotlyjs="cdn")
+    logger.info("%s: saved interactive equity chart %s", ticker, path)
+    return path
+
+
+def build_equity_figure(result: SimulationResult, ticker: str):
+    """Plotly figure overlaying strategy vs BH vs RF (shared by HTML export + app)."""
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    fig.add_scatter(
+        x=result.equity.index,
+        y=result.equity.values,
+        name="Strategy (after costs)",
+        line=dict(color="#1f77b4", width=2),
+    )
+    fig.add_scatter(
+        x=result.benchmark_bh.index,
+        y=result.benchmark_bh.values,
+        name="Buy & hold",
+        line=dict(color="#ff7f0e"),
+    )
+    fig.add_scatter(
+        x=result.benchmark_rf.index,
+        y=result.benchmark_rf.values,
+        name=f"Risk-free ({result.rf_annual:.1%})",
+        line=dict(color="#2ca02c", dash="dash"),
+    )
+    title = f"{ticker}: simulated equity (out-of-sample, after costs)"
+    title += f"<br><sup>{config.DISCLAIMER}</sup>"
+    fig.update_layout(
+        title=title,
+        xaxis_title="Date",
+        yaxis_title="Equity (start = 1.0)",
+        xaxis_rangeslider_visible=True,
+    )
+    return fig
 
 
 def write_interactive_html(

--- a/stockpredictor/portfolio.py
+++ b/stockpredictor/portfolio.py
@@ -1,0 +1,236 @@
+"""
+Paper-trading simulator — the heart of the simulated betting layer.
+
+Walks time forward one rebalance at a time. At each monthly rebalance date *t* it
+asks a ``WeightFn`` for a target weight, computes the trade against the current
+book, **applies costs**, then marks the book to market over the *next* period.
+The equity curve it produces is out-of-sample by construction: the weight chosen
+at *t* is shown only prices with timestamps ≤ *t*, while the return it earns is
+the realized move from *t* to *t+1* — data the weight never saw.
+
+Two benchmarks are simulated on the identical dates and costs:
+
+- **Buy-and-hold (BH):** fully invested in the asset from the first rebalance,
+  paying the entry cost once.
+- **Risk-free (RF):** compounds a configured annual rate (a constant default,
+  which emits a warning — it is not a real T-bill series).
+
+Guardrails honored here (execution brief §3): no lookahead (the ``peek``
+parameter exists *only* so a test can deliberately leak the future and prove the
+production path does not), costs always on, and both benchmarks always computed.
+
+Everything is injectable and offline: the simulator never touches the network. A
+``WeightFn`` encapsulates signal → strategy → sizing behind one callable, so this
+module stays independent of those stages (they land in later phases) and tests can
+drive it with a trivial fixed-weight strategy.
+
+⚠ Educational demo — not financial advice. Paper trading only; no orders are placed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+from . import config
+from .costs import TradingCosts, apply_costs
+
+logger = logging.getLogger("stockpredictor.portfolio")
+
+# A weight function maps (price history with timestamps ≤ t, config) -> target
+# weight in [0, max_weight]. The simulator is responsible for the point-in-time
+# slice; the function must only read the series it is handed.
+WeightFn = Callable[[pd.Series, config.AppConfig], float]
+
+
+class InsufficientHistoryError(ValueError):
+    """Raised when there is not enough history to run even one rebalance."""
+
+
+@dataclass
+class SimulationResult:
+    """Outcome of one paper-trading run plus its two benchmarks."""
+
+    equity: pd.Series  # strategy equity curve, starts at 1.0 at the first rebalance
+    weights: pd.Series  # target weight chosen at each rebalance date
+    trades: pd.DataFrame  # per-rebalance: weight_before/after, turnover, cost, equity
+    benchmark_bh: pd.Series  # buy-and-hold equity on the same dates/costs
+    benchmark_rf: pd.Series  # risk-free equity on the same dates
+    costs: TradingCosts
+    rf_annual: float
+    warmup: int
+    peek: int = 0  # >0 means the run intentionally leaked the future (tests only)
+    notes: list[str] = field(default_factory=list)
+
+
+def fixed_weight_fn(weight: float) -> WeightFn:
+    """A trivial strategy that always targets ``weight`` — validates the harness."""
+
+    def _fn(_history: pd.Series, _cfg: config.AppConfig) -> float:
+        return weight
+
+    return _fn
+
+
+def _buy_and_hold(prices: np.ndarray, first: int, costs: TradingCosts) -> list[float]:
+    """Fully invested from ``first``; pays the entry cost once, then compounds.
+
+    Entry buys weight 1.0 from a flat book, so the traded notional is the full
+    starting equity of 1.0 — the same cost the strategy would pay to reach full
+    investment, keeping the comparison fair.
+    """
+    equity = 1.0 - apply_costs(1.0, costs)
+    curve = [1.0]
+    for i in range(first, len(prices) - 1):
+        r = prices[i + 1] / prices[i] - 1.0
+        equity *= 1.0 + r
+        curve.append(equity)
+    return curve
+
+
+def _risk_free(n_steps: int, rf_period: float) -> list[float]:
+    """Compound the per-period risk-free rate for ``n_steps`` holding periods."""
+    equity = 1.0
+    curve = [1.0]
+    for _ in range(n_steps):
+        equity *= 1.0 + rf_period
+        curve.append(equity)
+    return curve
+
+
+def simulate(
+    monthly: pd.Series,
+    weight_fn: WeightFn,
+    cfg: config.AppConfig,
+    *,
+    costs: TradingCosts | None = None,
+    warmup: int | None = None,
+    peek: int = 0,
+) -> SimulationResult:
+    """Run a monthly, long-only, cost-aware paper-trading backtest.
+
+    Parameters
+    ----------
+    monthly:
+        Month-end price series (the same series ``forecast``/``pipeline`` use).
+    weight_fn:
+        Maps the point-in-time price history to a target weight in
+        ``[0, cfg.max_weight]``. The simulator clips to that range.
+    costs:
+        Transaction-cost model; defaults to ``TradingCosts.from_config(cfg)``.
+    warmup:
+        Months of history required before the first trade (defaults to
+        ``config.SIM_WARMUP_MONTHS``). Uninvested capital earns the risk-free rate.
+    peek:
+        Number of future periods to leak into ``weight_fn`` — **0 in production**.
+        A value > 0 deliberately violates point-in-time discipline and exists only
+        so the leakage test can show that peeking improves results (and that the
+        real path, ``peek=0``, does not). Logged loudly when non-zero.
+
+    Returns
+    -------
+    SimulationResult with the strategy equity curve and both benchmarks aligned on
+    identical dates, all starting at 1.0 at the first rebalance.
+    """
+    costs = costs or TradingCosts.from_config(cfg)
+    warmup = config.SIM_WARMUP_MONTHS if warmup is None else warmup
+    if peek:
+        logger.warning(
+            "simulate() called with peek=%d — LEAKING %d future period(s); "
+            "this is a leakage diagnostic and must never be a reported result.",
+            peek,
+            peek,
+        )
+
+    n = len(monthly)
+    first = max(int(warmup), 1)
+    # Need ``first`` history points to form a signal plus at least one forward
+    # return to realize. Below that, no honest rebalance is possible.
+    if n - first < 2:
+        raise InsufficientHistoryError(
+            f"need >= warmup+2 ({first + 2}) monthly points to simulate, got {n}"
+        )
+
+    prices = monthly.to_numpy(dtype=float)
+    dates = monthly.index
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    max_w = float(cfg.max_weight)
+
+    equity = 1.0
+    w_prev = 0.0
+    eq_curve: list[float] = [1.0]
+    eq_dates: list[pd.Timestamp] = [dates[first]]
+    weight_vals: list[float] = []
+    weight_dates: list[pd.Timestamp] = []
+    trade_rows: list[dict[str, float]] = []
+
+    for i in range(first, n - 1):
+        # Point-in-time slice: prices with timestamps ≤ t (peek>0 leaks the future).
+        hist_end = min(i + peek, n - 1)
+        hist = monthly.iloc[: hist_end + 1]
+        w_target = float(np.clip(float(weight_fn(hist, cfg)), 0.0, max_w))
+
+        turnover = abs(w_target - w_prev)
+        notional = turnover * equity
+        cost = apply_costs(notional, costs)
+        equity_after_cost = equity - cost
+
+        r_next = prices[i + 1] / prices[i] - 1.0
+        invested = w_target * equity_after_cost
+        cash = (1.0 - w_target) * equity_after_cost
+        equity = invested * (1.0 + r_next) + cash * (1.0 + rf_period)
+
+        weight_vals.append(w_target)
+        weight_dates.append(dates[i])
+        trade_rows.append(
+            {
+                "weight_before": w_prev,
+                "weight_after": w_target,
+                "turnover": turnover,
+                "cost": cost,
+                "equity": equity,
+            }
+        )
+        eq_curve.append(equity)
+        eq_dates.append(dates[i + 1])
+        w_prev = w_target
+
+    eq_index = pd.DatetimeIndex(eq_dates)
+    equity_series = pd.Series(eq_curve, index=eq_index, name="strategy")
+    weights_series = pd.Series(weight_vals, index=pd.DatetimeIndex(weight_dates), name="weight")
+    trades = pd.DataFrame(trade_rows, index=pd.DatetimeIndex(weight_dates))
+
+    n_steps = len(eq_curve) - 1
+    bh_series = pd.Series(_buy_and_hold(prices, first, costs), index=eq_index, name="buy_and_hold")
+    rf_series = pd.Series(_risk_free(n_steps, rf_period), index=eq_index, name="risk_free")
+
+    notes = [config.DISCLAIMER]
+    if cfg.rf_annual == config.RF_ANNUAL:
+        notes.append(
+            f"risk-free benchmark uses a constant {cfg.rf_annual:.2%} annual rate "
+            "(default), not a point-in-time T-bill series"
+        )
+
+    return SimulationResult(
+        equity=equity_series,
+        weights=weights_series,
+        trades=trades,
+        benchmark_bh=bh_series,
+        benchmark_rf=rf_series,
+        costs=costs,
+        rf_annual=cfg.rf_annual,
+        warmup=first,
+        peek=peek,
+        notes=notes,
+    )
+
+
+def total_return(equity: pd.Series) -> float:
+    """Cumulative return of an equity curve (final / initial − 1)."""
+    if len(equity) < 2 or equity.iloc[0] == 0:
+        return float("nan")
+    return float(equity.iloc[-1] / equity.iloc[0] - 1.0)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,0 +1,46 @@
+"""Tests for the pure transaction-cost model."""
+
+from __future__ import annotations
+
+import pytest
+
+from stockpredictor.costs import TradingCosts, apply_costs
+
+
+def test_per_notional_bps_uses_half_spread():
+    c = TradingCosts(commission_bps=1.0, spread_bps=6.0, slippage_bps=2.0, fixed_fee=0.0)
+    # commission + spread/2 + slippage = 1 + 3 + 2 = 6 bps
+    assert c.per_notional_bps == 6.0
+
+
+def test_apply_costs_scales_with_notional():
+    c = TradingCosts(commission_bps=0.0, spread_bps=0.0, slippage_bps=10.0)
+    # 10 bps of 1000 = 1.0
+    assert apply_costs(1000.0, c) == pytest.approx(1.0)
+    # Doubling notional doubles cost.
+    assert apply_costs(2000.0, c) == pytest.approx(2.0)
+
+
+def test_apply_costs_is_sign_independent_and_monotonic():
+    c = TradingCosts()
+    assert apply_costs(-500.0, c) == apply_costs(500.0, c)
+    assert apply_costs(1000.0, c) > apply_costs(500.0, c) > apply_costs(0.0, c)
+
+
+def test_zero_notional_pays_no_fixed_fee():
+    c = TradingCosts(fixed_fee=5.0)
+    assert apply_costs(0.0, c) == 0.0
+    # A non-zero trade does pay the fixed fee on top of the variable cost.
+    assert apply_costs(100.0, c) > 5.0
+
+
+def test_negative_params_rejected():
+    with pytest.raises(ValueError):
+        TradingCosts(slippage_bps=-1.0)
+
+
+def test_from_config_reads_cfg(cfg):
+    c = TradingCosts.from_config(cfg)
+    assert c.commission_bps == cfg.commission_bps
+    assert c.spread_bps == cfg.spread_bps
+    assert c.slippage_bps == cfg.slippage_bps

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,156 @@
+"""Tests for the paper-trading simulator: leakage, costs, benchmarks, determinism."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockpredictor import config
+from stockpredictor.costs import TradingCosts
+from stockpredictor.portfolio import (
+    InsufficientHistoryError,
+    fixed_weight_fn,
+    simulate,
+    total_return,
+)
+
+
+@pytest.fixture
+def random_walk() -> pd.Series:
+    """120 months of a driftless geometric random walk (no predictable structure)."""
+    idx = pd.date_range("2010-01-31", periods=120, freq="ME")
+    rng = np.random.default_rng(0)
+    rets = rng.normal(0.0, 0.05, 120)
+    return pd.Series(100.0 * np.exp(np.cumsum(rets)), index=idx)
+
+
+def _momentum_fn(history: pd.Series, _cfg: config.AppConfig) -> float:
+    """Go long iff the most recently observed return is positive."""
+    if len(history) < 2:
+        return 0.0
+    return 1.0 if history.iloc[-1] / history.iloc[-2] - 1.0 > 0 else 0.0
+
+
+def test_benchmarks_share_index_and_start_at_one(random_walk, cfg):
+    res = simulate(random_walk, fixed_weight_fn(1.0), cfg)
+    assert res.equity.index.equals(res.benchmark_bh.index)
+    assert res.equity.index.equals(res.benchmark_rf.index)
+    assert res.equity.iloc[0] == pytest.approx(1.0)
+    assert res.benchmark_bh.iloc[0] == pytest.approx(1.0)
+    assert res.benchmark_rf.iloc[0] == pytest.approx(1.0)
+
+
+def test_insufficient_history_raises(cfg):
+    short = pd.Series(
+        np.linspace(10, 12, 5), index=pd.date_range("2024-01-31", periods=5, freq="ME")
+    )
+    with pytest.raises(InsufficientHistoryError):
+        simulate(short, fixed_weight_fn(1.0), cfg, warmup=6)
+
+
+def test_weight_is_clipped_to_long_only_range(random_walk, cfg):
+    over = simulate(random_walk, fixed_weight_fn(5.0), cfg)  # > max_weight
+    under = simulate(random_walk, fixed_weight_fn(-2.0), cfg)  # < 0 (no shorting)
+    assert (over.weights <= cfg.max_weight + 1e-12).all()
+    assert (under.weights >= -1e-12).all()
+    assert (under.weights == 0.0).all()
+
+
+def test_full_invest_costless_matches_buy_and_hold(random_walk):
+    """Fully invested with zero costs is exactly buy-and-hold."""
+    free = config.AppConfig(commission_bps=0.0, spread_bps=0.0, slippage_bps=0.0)
+    res = simulate(random_walk, fixed_weight_fn(1.0), free)
+    assert np.allclose(res.equity.values, res.benchmark_bh.values)
+    # And buy-and-hold equals the realized price return over the traded window.
+    prices = random_walk.to_numpy()
+    first = res.warmup
+    assert total_return(res.benchmark_bh) == pytest.approx(prices[-1] / prices[first] - 1.0)
+
+
+def test_all_cash_earns_risk_free(random_walk, cfg):
+    """Weight 0 never trades, so the book is all cash compounding at the RF rate."""
+    res = simulate(random_walk, fixed_weight_fn(0.0), cfg)
+    assert np.allclose(res.equity.values, res.benchmark_rf.values)
+    assert res.trades["cost"].sum() == 0.0  # nothing ever traded
+
+
+def test_risk_free_benchmark_compounds(random_walk, cfg):
+    res = simulate(random_walk, fixed_weight_fn(0.5), cfg)
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    n_steps = len(res.benchmark_rf) - 1
+    assert res.benchmark_rf.iloc[-1] == pytest.approx((1.0 + rf_period) ** n_steps)
+
+
+def test_cost_param_monotonicity(random_walk):
+    """Holding the weight path fixed, higher cost params give strictly lower return."""
+    fn = fixed_weight_fn(1.0)
+    cheap = config.AppConfig(commission_bps=1.0, spread_bps=2.0, slippage_bps=2.0)
+    mid = config.AppConfig(commission_bps=5.0, spread_bps=10.0, slippage_bps=10.0)
+    pricey = config.AppConfig(commission_bps=20.0, spread_bps=40.0, slippage_bps=40.0)
+    r_cheap = total_return(simulate(random_walk, fn, cheap).equity)
+    r_mid = total_return(simulate(random_walk, fn, mid).equity)
+    r_pricey = total_return(simulate(random_walk, fn, pricey).equity)
+    assert r_cheap > r_mid > r_pricey
+
+
+def test_higher_turnover_pays_more_cost(random_walk, cfg):
+    """A strategy that flips every period pays strictly more total cost than holding."""
+
+    flips = {"n": 0}
+
+    def flip_fn(_history: pd.Series, _cfg: config.AppConfig) -> float:
+        flips["n"] += 1
+        return float(flips["n"] % 2)  # 1, 0, 1, 0, ... -> turnover 1.0 every step
+
+    hold_cost = simulate(random_walk, fixed_weight_fn(1.0), cfg).trades["cost"].sum()
+    flip_cost = simulate(random_walk, flip_fn, cfg).trades["cost"].sum()
+    assert flip_cost > hold_cost > 0.0
+
+
+def test_leakage_peek_improves_results(random_walk, cfg):
+    """Shifting the signal one period into the future must markedly improve results.
+
+    The production path (peek=0) sees only past returns and has no edge on a random
+    walk; peek=1 lets the same momentum rule see the about-to-be-realized return and
+    time the market perfectly. If peeking did NOT improve things, the harness would
+    be leaking the future on the production path — this test is the leakage tripwire.
+    """
+    honest = total_return(simulate(random_walk, _momentum_fn, cfg, peek=0).equity)
+    peeking = total_return(simulate(random_walk, _momentum_fn, cfg, peek=1).equity)
+    bh = total_return(simulate(random_walk, fixed_weight_fn(1.0), cfg).benchmark_bh)
+    assert peeking > honest + 0.5  # peeking captures large, obvious gains
+    assert peeking > bh  # and trounces buy-and-hold
+    # The honest path does NOT clear buy-and-hold by the leakage margin.
+    assert honest < peeking - 0.5
+
+
+def test_determinism(random_walk, cfg):
+    a = simulate(random_walk, _momentum_fn, cfg)
+    b = simulate(random_walk, _momentum_fn, cfg)
+    assert np.array_equal(a.equity.values, b.equity.values)
+    assert np.array_equal(a.weights.values, b.weights.values)
+
+
+def test_disclaimer_in_notes(random_walk, cfg):
+    res = simulate(random_walk, fixed_weight_fn(1.0), cfg)
+    assert any(config.DISCLAIMER in note for note in res.notes)
+
+
+def test_custom_costs_override_config(random_walk, cfg):
+    """An explicit TradingCosts argument takes precedence over the config."""
+    free = TradingCosts(commission_bps=0.0, spread_bps=0.0, slippage_bps=0.0)
+    res = simulate(random_walk, fixed_weight_fn(1.0), cfg, costs=free)
+    assert res.trades["cost"].sum() == 0.0
+
+
+def test_equity_plot_renders(random_walk, cfg, tmp_path):
+    """The strategy-vs-BH-vs-RF overlay PNG renders to a non-empty file."""
+    from stockpredictor import plotting
+
+    res = simulate(random_walk, fixed_weight_fn(1.0), cfg)
+    path = plotting.plot_equity_curve(res, "NVDA", str(tmp_path), cfg)
+    assert path.endswith("NVDA_SIM_equity.png")
+    import os
+
+    assert os.path.getsize(path) > 0


### PR DESCRIPTION
## Phase 1 of the simulated betting / position-sizing layer

First reviewable unit of the execution brief (§8). It stands up and **validates the walk-forward simulation harness with a trivial fixed-weight strategy**, before any real signal exists. No signal/strategy/sizing logic yet — that lands in Phases 2–3.

### What's here
- **`costs.py`** — pure, deterministic `TradingCosts` + `apply_costs`. Cost = `|notional| · (commission + spread/2 + slippage)/1e4 (+ fixed fee)`. Scales with traded notional/turnover. There is **no gross-of-cost path**.
- **`portfolio.py`** — point-in-time, monthly, long-only simulator. At each rebalance the weight is formed from prices with timestamps **≤ t** and earns the realized **t → t+1** return, so the equity curve is out-of-sample *by construction*. Uninvested cash earns the risk-free rate. **Buy-and-hold** and **risk-free** benchmarks are simulated on identical dates and costs. A `peek` parameter exists **only** so the leakage test can deliberately leak the future and prove the production path (`peek=0`) does not.
- **`config.py`** — trading-cost / RF / sizing constants, matching `AppConfig` fields, and a shared `periodic_rate` helper (one RF convention everywhere).
- **`plotting.py`** — strategy-vs-BH-vs-RF equity overlay (matplotlib PNG + Plotly HTML), `not-financial-advice` disclaimer on every surface.

### Guardrails honored (brief §3)
- ✅ No lookahead — enforced by the harness slice; a **leakage tripwire test** asserts that peeking one period ahead improves results markedly (and the honest path does not).
- ✅ Costs always on; both benchmarks always computed.
- ✅ Paper-trading only — moves numbers in memory, no orders, no broker, no API keys.

### Tests (all green, mocked/offline, deterministic seeds)
leakage tripwire · cost-param monotonicity · turnover→cost · costless full-invest == buy-and-hold · all-cash == risk-free · RF compounding · determinism · insufficient-history guard · long-only clipping · equity-plot smoke.

`ruff check` + `ruff format --check` + `mypy stockpredictor` clean; pytest suite green across the existing 3.9/3.11/3.12 matrix; coverage ~90%.

### Deferred (later phases, by design)
`signals.py` / `strategy.py` (Phase 2), `sizing.py` (Phase 3), evaluation scorecard + `store.py` run-logging + multiple-testing warning + CLI/dashboard surfaces + README section (Phase 4). Phase 5 is sign-off-gated.

> ⚠️ Educational demo — not financial advice. Paper trading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)