### PR TITLE
feat(sim): Phase 2 — signal extraction + long-only threshold strategy

### DIFF
--- a/stockpredictor/config.py
+++ b/stockpredictor/config.py
@@ -61,6 +61,7 @@ MAX_WEIGHT = 1.0  # long-only, no leverage: weight is clipped to [0, 1]
 TARGET_VOL = 0.10  # annualized volatility target for vol-sizing
 KELLY_FRACTION = 0.25  # fractional Kelly (full Kelly is never the default)
 CONFIDENCE_FLOOR = 0.0  # minimum signal confidence to take any position
+MIN_EXCESS_RETURN = 0.0  # per-period excess return (μ−rf) required to go long
 SIM_WARMUP_MONTHS = MIN_MONTHS_FOR_ANY_FIT  # history needed before the first trade
 HOLDOUT_PERIODS = 12  # final out-of-sample slice, touched exactly once
 
@@ -122,6 +123,7 @@ class AppConfig:
     target_vol: float = TARGET_VOL
     kelly_fraction: float = KELLY_FRACTION
     confidence_floor: float = CONFIDENCE_FLOOR
+    min_excess_return: float = MIN_EXCESS_RETURN  # per-period μ−rf above which we go long
     sizing_method: str = "vol"  # "vol" (volatility targeting) | "kelly"
     holdout_periods: int = HOLDOUT_PERIODS
 

--- a/stockpredictor/signals.py
+++ b/stockpredictor/signals.py
@@ -1,0 +1,133 @@
+"""
+Signal extraction: turn a forecast (point path + prediction intervals + sentiment)
+into a normalized trading ``Signal``. This module is *translation only* — there is
+deliberately no trading logic here (that lives in ``strategy.py`` / ``sizing.py``).
+
+A ``Signal`` carries three numbers and a timestamp:
+
+- ``expected_return`` (μ): the one-rebalance-ahead forecast return, i.e. the
+  horizon-1 point forecast expressed as a return off the last observed price.
+- ``uncertainty`` (σ): a per-period return standard deviation *derived from the
+  existing prediction interval*, not invented. Under a normal approximation an 80%
+  two-sided band spans ±1.2816σ, so σ ≈ (upper₈₀ − lower₈₀) / (2 · 1.2816). Wider
+  bands ⇒ larger σ ⇒ (downstream) smaller positions. The normal approximation is an
+  assumption; the bands themselves come from Monte-Carlo simulation of the fit.
+- ``confidence``: the existing sentiment sample-size + agreement score in [0, 1]
+  (0 when there is no news). It is reused here unchanged so the strategy can
+  optionally gate on it; with the default ``confidence_floor`` of 0 it is non-binding.
+
+The ``SignalFn`` seam mirrors ``portfolio.WeightFn``: given the point-in-time price
+history (timestamps ≤ t), produce the Signal valid as-of t. The real implementation
+fits the forecast on that history; tests inject cheap synthetic signal functions.
+
+⚠ Educational demo — not financial advice.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+import pandas as pd
+
+from . import config, forecast
+from .forecast import ForecastResult
+from .sentiment import SentimentResult
+
+logger = logging.getLogger("stockpredictor.signals")
+
+# Two-sided normal z-scores: an 80% band is ±1.2816σ, a 95% band ±1.9600σ. Used to
+# back out σ from a prediction-interval half-width (norm.ppf(0.90) / norm.ppf(0.975)).
+_Z80 = 1.2815515594
+_Z95 = 1.9599639845
+
+# Floor on σ so downstream sizing never divides by ~0 (a vanishing band would imply
+# infinite conviction, which is never warranted from an estimated model).
+_MIN_SIGMA = 1e-6
+
+
+@dataclass(frozen=True)
+class Signal:
+    """A normalized, point-in-time trading signal (no position logic attached)."""
+
+    expected_return: float  # μ: one-period-ahead expected return (decimal, e.g. 0.01)
+    uncertainty: float  # σ: per-period return standard deviation (> 0)
+    confidence: float  # [0, 1]; reused sentiment sample-size + agreement score
+    as_of: pd.Timestamp  # the timestamp this signal may be acted on
+
+    def __post_init__(self) -> None:
+        if self.uncertainty <= 0:
+            raise ValueError(f"uncertainty (σ) must be positive, got {self.uncertainty}")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"confidence must be in [0, 1], got {self.confidence}")
+
+
+# A signal function maps (point-in-time price history, config) -> Signal.
+SignalFn = Callable[[pd.Series, config.AppConfig], Signal]
+
+
+def _sigma_from_intervals(fc: ForecastResult, last_price: float) -> float:
+    """Back out a per-period return σ from the horizon-1 prediction interval.
+
+    Prefers the 80% band (most points fall inside it, so it is the better-estimated
+    half-width), falls back to the 95% band, and finally to a small floor if no band
+    is available. The band is in price space around the point forecast; dividing the
+    return-space half-width by the normal z-score recovers σ.
+    """
+    for coverage, z in ((80, _Z80), (95, _Z95)):
+        band = fc.intervals.get(coverage)
+        if band is None:
+            continue
+        lower, upper = band
+        half_width_price = (float(upper.iloc[0]) - float(lower.iloc[0])) / 2.0
+        sigma = (half_width_price / z) / last_price
+        if sigma > 0:
+            return sigma
+    logger.debug("No usable prediction interval for σ; falling back to σ floor.")
+    return _MIN_SIGMA
+
+
+def signal_from_forecast(
+    fc: ForecastResult,
+    last_price: float,
+    *,
+    sentiment: SentimentResult | None = None,
+    as_of: pd.Timestamp | None = None,
+) -> Signal:
+    """Translate a ``ForecastResult`` into a ``Signal`` (μ, σ, confidence, as-of).
+
+    μ is the horizon-1 forecast return; σ comes from the interval width; confidence
+    is the sentiment score (0 when no news / sentiment unavailable).
+    """
+    point0 = float(fc.point.iloc[0])
+    mu = point0 / last_price - 1.0
+    sigma = max(_sigma_from_intervals(fc, last_price), _MIN_SIGMA)
+    confidence = sentiment.confidence if (sentiment is not None and sentiment.has_news) else 0.0
+    as_of = as_of if as_of is not None else fc.point.index[0]
+    return Signal(expected_return=mu, uncertainty=sigma, confidence=float(confidence), as_of=as_of)
+
+
+def make_signal_fn(
+    cfg: config.AppConfig,
+    *,
+    sentiment: SentimentResult | None = None,
+) -> SignalFn:
+    """Build the production ``SignalFn`` that fits the forecast on point-in-time data.
+
+    At each rebalance it refits Holt-Winters on the supplied history (timestamps ≤ t),
+    takes the one-month-ahead point + intervals, and folds in the (optional) sentiment
+    confidence. ``sentiment`` is held fixed across the walk for now; a point-in-time
+    sentiment panel is future work (brief §8 Phase 5).
+    """
+
+    def _fn(history: pd.Series, cfg_in: config.AppConfig) -> Signal:
+        fc = forecast.forecast_with_intervals(history, cfg_in, horizon=1)
+        return signal_from_forecast(
+            fc,
+            last_price=float(history.iloc[-1]),
+            sentiment=sentiment,
+            as_of=history.index[-1],
+        )
+
+    return _fn

--- a/stockpredictor/strategy.py
+++ b/stockpredictor/strategy.py
@@ -1,0 +1,101 @@
+"""
+Strategy: map a ``Signal`` to a *target* position, applying the long-only
+constraints and the entry threshold. This is where "should I hold this at all?"
+is decided; *how much* to hold (vol-targeting / fractional Kelly) is ``sizing.py``
+(Phase 3), which plugs into ``make_weight_fn`` below.
+
+The default rule is deliberately simple and testable:
+
+- If the signal's confidence is below ``cfg.confidence_floor`` → weight 0.
+- If the expected return is not above the risk-free rate by at least
+  ``cfg.min_excess_return`` → weight 0 (no edge over cash ⇒ no position).
+- Otherwise the strategy expresses full conviction (``cfg.max_weight``); long-only,
+  so the weight is never negative.
+
+Strategy/parameter choices are captured by ``variant_id`` so every backtested
+variant can be logged and counted — the multiple-testing discipline of brief §3.5
+(the best-looking of N variants is likely overfit).
+
+⚠ Educational demo — not financial advice.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable
+
+import pandas as pd
+
+from . import config
+from .signals import Signal, SignalFn
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .portfolio import WeightFn
+
+logger = logging.getLogger("stockpredictor.strategy")
+
+# How sizing converts a Signal into a position fraction (filled in by sizing.py).
+SizingFn = Callable[[Signal, config.AppConfig], float]
+
+
+def target_weight(signal: Signal, cfg: config.AppConfig) -> float:
+    """Long-only threshold rule: full conviction when the signal beats cash, else 0.
+
+    Returns a value in ``[0, cfg.max_weight]``. ``sizing.py`` later scales this
+    conviction down to a risk-calibrated fraction; on its own (Phase 2) the strategy
+    is "all-in when bullish, flat otherwise".
+    """
+    if signal.confidence < cfg.confidence_floor:
+        return 0.0
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    excess = signal.expected_return - rf_period
+    if excess <= cfg.min_excess_return:
+        return 0.0
+    return float(min(max(cfg.max_weight, 0.0), cfg.max_weight))
+
+
+def make_weight_fn(
+    signal_fn: SignalFn,
+    *,
+    sizing_fn: SizingFn | None = None,
+) -> WeightFn:
+    """Compose ``signal → strategy gate → (optional) sizing`` into a ``WeightFn``.
+
+    The returned function is what ``portfolio.simulate`` drives. The strategy gate
+    decides whether to be in the market at all; when it is, ``sizing_fn`` (Phase 3)
+    sets the magnitude, clipped to ``[0, max_weight]``. Without a ``sizing_fn`` the
+    strategy's own conviction is used directly. Point-in-time discipline is the
+    simulator's job: ``signal_fn`` only ever sees the history it is handed.
+    """
+
+    def _fn(history: pd.Series, cfg: config.AppConfig) -> float:
+        signal = signal_fn(history, cfg)
+        conviction = target_weight(signal, cfg)
+        if conviction <= 0.0:
+            return 0.0
+        if sizing_fn is None:
+            return conviction
+        fraction = sizing_fn(signal, cfg)
+        return float(min(max(fraction, 0.0), cfg.max_weight))
+
+    return _fn
+
+
+def variant_id(cfg: config.AppConfig) -> str:
+    """A readable, deterministic identity for the full strategy/cost configuration.
+
+    Logged with every simulation run so the reporting layer can count how many
+    variants were tried and warn that the best of N is likely overfit (brief §3.5).
+    """
+    return ";".join(
+        (
+            f"sizing={cfg.sizing_method}",
+            f"floor={cfg.confidence_floor:g}",
+            f"minexc={cfg.min_excess_return:g}",
+            f"maxw={cfg.max_weight:g}",
+            f"tvol={cfg.target_vol:g}",
+            f"kelly={cfg.kelly_fraction:g}",
+            f"cost={cfg.commission_bps:g}/{cfg.spread_bps:g}/{cfg.slippage_bps:g}",
+            f"rf={cfg.rf_annual:g}",
+        )
+    )

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,78 @@
+"""Tests for signal extraction: μ from the point forecast, σ from the intervals."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockpredictor import signals
+from stockpredictor.forecast import ForecastResult
+from stockpredictor.sentiment import aggregate_sentiment
+from stockpredictor.signals import Signal, signal_from_forecast
+
+
+def _forecast(point0: float, lo80: float, hi80: float, lo95=None, hi95=None) -> ForecastResult:
+    idx = pd.date_range("2025-01-31", periods=1, freq="ME")
+    intervals = {80: (pd.Series([lo80], index=idx), pd.Series([hi80], index=idx))}
+    if lo95 is not None:
+        intervals[95] = (pd.Series([lo95], index=idx), pd.Series([hi95], index=idx))
+    return ForecastResult(point=pd.Series([point0], index=idx), intervals=intervals)
+
+
+def test_mu_is_horizon1_return():
+    fc = _forecast(point0=110.0, lo80=105.0, hi80=115.0)
+    sig = signal_from_forecast(fc, last_price=100.0)
+    assert sig.expected_return == pytest.approx(0.10)  # 110/100 - 1
+
+
+def test_sigma_from_80_band_uses_normal_z():
+    # Half-width in price = (115-105)/2 = 5; σ_price = 5/1.2816; σ_ret = σ_price/100.
+    fc = _forecast(point0=110.0, lo80=105.0, hi80=115.0)
+    sig = signal_from_forecast(fc, last_price=100.0)
+    expected = (5.0 / signals._Z80) / 100.0
+    assert sig.uncertainty == pytest.approx(expected)
+
+
+def test_sigma_falls_back_to_95_band_when_80_absent():
+    idx = pd.date_range("2025-01-31", periods=1, freq="ME")
+    fc = ForecastResult(
+        point=pd.Series([110.0], index=idx),
+        intervals={95: (pd.Series([100.0], index=idx), pd.Series([120.0], index=idx))},
+    )
+    sig = signal_from_forecast(fc, last_price=100.0)
+    expected = (10.0 / signals._Z95) / 100.0  # half-width 10 over z95
+    assert sig.uncertainty == pytest.approx(expected)
+
+
+def test_sigma_floor_when_no_intervals():
+    idx = pd.date_range("2025-01-31", periods=1, freq="ME")
+    fc = ForecastResult(point=pd.Series([110.0], index=idx), intervals={})
+    sig = signal_from_forecast(fc, last_price=100.0)
+    assert sig.uncertainty == pytest.approx(signals._MIN_SIGMA)
+
+
+def test_confidence_comes_from_sentiment_else_zero():
+    fc = _forecast(point0=110.0, lo80=105.0, hi80=115.0)
+    assert signal_from_forecast(fc, 100.0).confidence == 0.0  # no sentiment
+    sent = aggregate_sentiment([0.3, 0.4, 0.35, 0.5])  # agreeing, positive
+    sig = signal_from_forecast(fc, 100.0, sentiment=sent)
+    assert sig.confidence == pytest.approx(sent.confidence)
+    assert sig.confidence > 0.0
+
+
+def test_signal_rejects_bad_values():
+    ts = pd.Timestamp("2025-01-31")
+    with pytest.raises(ValueError):
+        Signal(expected_return=0.0, uncertainty=0.0, confidence=0.5, as_of=ts)
+    with pytest.raises(ValueError):
+        Signal(expected_return=0.0, uncertainty=0.1, confidence=1.5, as_of=ts)
+
+
+def test_make_signal_fn_runs_real_forecast(monthly, cfg):
+    sig_fn = signals.make_signal_fn(cfg)
+    sig = sig_fn(monthly, cfg)
+    assert isinstance(sig, Signal)
+    assert sig.uncertainty > 0.0
+    assert sig.as_of == monthly.index[-1]
+    assert np.isfinite(sig.expected_return)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,140 @@
+"""Tests for the long-only threshold strategy and the signal→weight composition.
+
+Includes the brief's zero-edge and known-edge synthetic checks: the strategy must
+not manufacture an edge from noise, and must capture a real, lagged one.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockpredictor import config, strategy
+from stockpredictor.portfolio import simulate, total_return
+from stockpredictor.signals import Signal
+
+
+def _signal(mu: float, confidence: float = 1.0, sigma: float = 0.05) -> Signal:
+    return Signal(
+        expected_return=mu,
+        uncertainty=sigma,
+        confidence=confidence,
+        as_of=pd.Timestamp("2025-01-31"),
+    )
+
+
+def test_long_when_excess_return_positive():
+    cfg = config.AppConfig()
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    assert strategy.target_weight(_signal(rf_period + 0.05), cfg) == cfg.max_weight
+
+
+def test_flat_when_no_excess_over_cash():
+    cfg = config.AppConfig()
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    assert strategy.target_weight(_signal(rf_period), cfg) == 0.0  # exactly rf -> no edge
+    assert strategy.target_weight(_signal(-0.10), cfg) == 0.0  # bearish
+
+
+def test_long_only_never_negative():
+    cfg = config.AppConfig()
+    for mu in (-0.5, -0.01, 0.0, 0.2):
+        assert strategy.target_weight(_signal(mu), cfg) >= 0.0
+
+
+def test_confidence_floor_gates_position():
+    cfg = config.AppConfig(confidence_floor=0.5)
+    bullish = _signal(0.05, confidence=0.2)  # would be long but confidence too low
+    assert strategy.target_weight(bullish, cfg) == 0.0
+    assert strategy.target_weight(_signal(0.05, confidence=0.9), cfg) == cfg.max_weight
+
+
+def test_min_excess_return_raises_the_bar():
+    cfg = config.AppConfig(min_excess_return=0.02)
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    assert strategy.target_weight(_signal(rf_period + 0.01), cfg) == 0.0  # below the bar
+    assert strategy.target_weight(_signal(rf_period + 0.03), cfg) == cfg.max_weight
+
+
+def test_make_weight_fn_without_sizing_is_full_conviction():
+    cfg = config.AppConfig()
+    bullish = lambda _h, _c: _signal(0.05)  # noqa: E731
+    bearish = lambda _h, _c: _signal(-0.05)  # noqa: E731
+    hist = pd.Series([1.0, 2.0])
+    assert strategy.make_weight_fn(bullish)(hist, cfg) == cfg.max_weight
+    assert strategy.make_weight_fn(bearish)(hist, cfg) == 0.0
+
+
+def test_make_weight_fn_applies_and_clips_sizing():
+    cfg = config.AppConfig(max_weight=0.8)
+    bullish = lambda _h, _c: _signal(0.05)  # noqa: E731
+    hist = pd.Series([1.0, 2.0])
+    # Sizing over the cap is clipped to max_weight; a gated-out signal stays 0.
+    over = strategy.make_weight_fn(bullish, sizing_fn=lambda _s, _c: 5.0)
+    half = strategy.make_weight_fn(bullish, sizing_fn=lambda _s, _c: 0.3)
+    neg = strategy.make_weight_fn(bullish, sizing_fn=lambda _s, _c: -1.0)
+    assert over(hist, cfg) == 0.8
+    assert half(hist, cfg) == pytest.approx(0.3)
+    assert neg(hist, cfg) == 0.0
+
+
+def test_variant_id_is_deterministic_and_sensitive():
+    a = strategy.variant_id(config.AppConfig())
+    b = strategy.variant_id(config.AppConfig())
+    c = strategy.variant_id(config.AppConfig(kelly_fraction=0.5))
+    assert a == b
+    assert a != c
+
+
+# --- Synthetic zero-edge / known-edge checks ---------------------------------
+def _momentum_signal(history: pd.Series, _cfg: config.AppConfig) -> Signal:
+    """Naive predictor: next return ≈ last observed return. Only works if returns
+    are serially correlated; on i.i.d. data it is pure noise."""
+    rets = history.pct_change().dropna()
+    mu = float(rets.iloc[-1])
+    sigma = max(float(rets.std()), 0.01)
+    return Signal(expected_return=mu, uncertainty=sigma, confidence=1.0, as_of=history.index[-1])
+
+
+def _ar1_prices(seed: int, phi: float, *, sigma: float = 0.05, drift: float = 0.0067, n: int = 160):
+    """Geometric series whose returns follow AR(1): r_t = drift + φ·r_{t-1} + ε.
+
+    ``drift`` (~8%/yr) makes buy-and-hold a *fair, strong* benchmark, so beating it
+    requires real timing skill — not just parking in cash to dodge volatility drag.
+    """
+    rng = np.random.default_rng(seed)
+    eps = rng.normal(0.0, sigma, n)
+    r = np.zeros(n)
+    for t in range(1, n):
+        r[t] = drift + phi * r[t - 1] + eps[t]
+    idx = pd.date_range("2008-01-31", periods=n, freq="ME")
+    return pd.Series(100.0 * np.exp(np.cumsum(r)), index=idx)
+
+
+def _wins_vs_buy_and_hold(phi: float, seeds: range) -> int:
+    cfg = config.AppConfig()
+    weight_fn = strategy.make_weight_fn(_momentum_signal)
+    wins = 0
+    for s in seeds:
+        res = simulate(_ar1_prices(s, phi), weight_fn, cfg)
+        if total_return(res.equity) > total_return(res.benchmark_bh):
+            wins += 1
+    return wins
+
+
+def test_zero_edge_does_not_reliably_beat_buy_and_hold():
+    """No serial structure (φ=0): the momentum strategy must NOT reliably beat BH
+    after costs. If it did, the harness would be flattering noise."""
+    seeds = range(20)
+    wins = _wins_vs_buy_and_hold(phi=0.0, seeds=seeds)
+    assert wins < len(seeds) * 0.4  # a minority — no durable edge
+
+
+def test_known_edge_is_captured():
+    """A real, lagged predictability (φ=0.4): the strategy should capture it and
+    beat BH in a strong majority of seeds. Guards against a sim/sizing bug that
+    destroys genuine signal."""
+    seeds = range(20)
+    wins = _wins_vs_buy_and_hold(phi=0.4, seeds=seeds)
+    assert wins >= len(seeds) * 0.75


### PR DESCRIPTION
## Phase 2 of the simulated betting / position-sizing layer

Builds on the Phase 1 simulator (#22). Turns the existing forecast into a normalized **signal**, maps it to a long-only **target weight**, and composes them into the `WeightFn` the simulator consumes. No sizing math yet — that's Phase 3, and the seam for it is already in place.

### What's here
- **`signals.py`** — *translation only*, no trading logic. `signal_from_forecast(ForecastResult) → Signal(μ, σ, confidence, as_of)`:
  - **μ** = horizon-1 forecast return off the last price.
  - **σ** = backed out of the prediction interval, not invented: 80% band half-width / 1.2816 under a normal approximation (documented assumption), 95% fallback, σ floor so downstream sizing never divides by ~0.
  - **confidence** = the existing sentiment sample-size + agreement score (0 when no news); non-binding by default (`confidence_floor=0`).
  - `make_signal_fn` builds the production point-in-time `SignalFn` (refits the forecast on history ≤ t).
- **`strategy.py`** — long-only threshold rule: weight 0 when confidence < floor or μ doesn't clear the risk-free rate by `min_excess_return`; full conviction (`max_weight`) otherwise; **never negative**. `make_weight_fn` composes `signal → gate → (optional) sizing`, leaving a clean Phase-3 hook. `variant_id` gives each strategy/cost config a readable identity for the multiple-testing accounting (§3.5) landing in Phase 4.

### Guardrail tests (brief §7)
- **Zero-edge:** i.i.d. returns with a *fair, positive-drift* buy-and-hold benchmark — the momentum strategy does **not** reliably beat BH after costs (a minority of seeds). The fair benchmark matters: on a *driftless* walk a timing strategy "wins" merely by parking in cash to dodge volatility drag, which would be a misleading pass. Using positive drift forces the test to isolate real predictive edge.
- **Known-edge:** AR(1), φ=0.4 — the strategy captures it and beats BH in a strong majority of seeds. Guards against a sim/sizing bug that silently destroys real signal.
- Both are **deterministic multi-seed aggregates** (20 seeds), not knife-edge single-seed asserts.
- Plus units: σ-from-interval (80/95/floor), μ mapping, confidence sourcing, `Signal` validation, real-forecast `SignalFn`, threshold/floor/long-only edges, sizing composition + clipping, `variant_id`.

`ruff` + `ruff format --check` + `mypy stockpredictor` clean; full suite **121 passing**; coverage **90.4%** (`signals.py` & `strategy.py` 100%).

### Deferred (by design)
`sizing.py` vol-targeting + fractional Kelly (Phase 3); evaluation scorecard + `store.py` run-logging + multiple-testing warning + CLI/dashboard surfaces + README (Phase 4).

> ⚠️ Educational demo — not financial advice. Paper trading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)