### PR TITLE
feat(sim): Phase 3 — position sizing (vol-targeting + fractional Kelly)

### DIFF
--- a/stockpredictor/sizing.py
+++ b/stockpredictor/sizing.py
@@ -1,0 +1,93 @@
+"""
+Position sizing: convert a ``Signal`` into a long-only position *fraction*.
+
+Two pure, fully-tested methods (the strategy gate in ``strategy.py`` has already
+decided *whether* to be in the market; sizing decides *how much*):
+
+- **Volatility targeting** (default, more robust): size so the position's expected
+  volatility hits ``cfg.target_vol`` (annualized). ``weight = target_vol /
+  forecast_vol``, capped at ``max_weight``. It ignores the magnitude of μ — a
+  calmer asset gets a bigger position, a wilder one a smaller position — which is
+  far less sensitive to noisy return estimates than Kelly.
+
+- **Fractional Kelly**: ``weight = clip(λ · μ_excess / σ², 0, max_weight)`` with
+  ``λ = cfg.kelly_fraction`` (default **0.25**). Full Kelly (λ=1) is *never* the
+  default: it maximizes long-run log-growth only with known parameters, and with
+  *estimated* μ/σ it badly over-bets and courts ruinous drawdowns, so estimation
+  error is punished by quartering the bet.
+
+Both take ``μ`` as the expected return *in excess of the risk-free rate* (brief §5)
+and are long-only: a non-positive excess returns weight 0, and the result never
+goes negative. σ is the per-period return standard deviation from ``signals.py``;
+vol targeting annualizes it by √12 to compare against the annual target.
+
+⚠ Educational demo — not financial advice.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from . import config
+from .signals import Signal
+
+logger = logging.getLogger("stockpredictor.sizing")
+
+
+def _excess_return(signal: Signal, cfg: config.AppConfig) -> float:
+    """Expected return in excess of the per-period risk-free rate."""
+    return signal.expected_return - config.periodic_rate(cfg.rf_annual)
+
+
+def _clip(raw: float, max_weight: float) -> float:
+    """Long-only clip into ``[0, max_weight]``."""
+    return float(min(max(raw, 0.0), max_weight))
+
+
+def vol_target_weight(signal: Signal, cfg: config.AppConfig) -> float:
+    """Volatility targeting: ``target_vol / forecast_vol``, capped at ``max_weight``.
+
+    As the forecast volatility shrinks the position grows and is capped at
+    ``max_weight`` (σ→0 ⇒ full position, never more). A non-positive excess return
+    yields weight 0 (long-only).
+    """
+    if _excess_return(signal, cfg) <= 0.0:
+        return 0.0
+    forecast_vol = signal.uncertainty * math.sqrt(config.PERIODS_PER_YEAR)
+    raw = cfg.target_vol / forecast_vol  # σ>0 (guaranteed by Signal) -> safe divide
+    return _clip(raw, cfg.max_weight)
+
+
+def kelly_weight(signal: Signal, cfg: config.AppConfig) -> float:
+    """Fractional Kelly: ``clip(λ · μ_excess / σ², 0, max_weight)``.
+
+    Defaults to a quarter-Kelly bet. A non-positive excess return yields 0, and a
+    vanishing σ² (extreme underflow) is treated as maximal conviction and capped at
+    ``max_weight`` rather than dividing by zero.
+    """
+    excess = _excess_return(signal, cfg)
+    if excess <= 0.0:
+        return 0.0
+    sigma2 = signal.uncertainty**2
+    if sigma2 == 0.0:  # underflow guard: σ² rounded to 0 -> cap, don't divide
+        return cfg.max_weight
+    raw = cfg.kelly_fraction * excess / sigma2
+    return _clip(raw, cfg.max_weight)
+
+
+_METHODS = {"vol": vol_target_weight, "kelly": kelly_weight}
+
+
+def size_position(signal: Signal, cfg: config.AppConfig) -> float:
+    """Dispatch to the sizing method named by ``cfg.sizing_method`` ("vol"|"kelly").
+
+    This is the ``SizingFn`` handed to ``strategy.make_weight_fn``; reading the
+    method from ``cfg`` each call keeps the choice a logged, swappable variant.
+    """
+    method = _METHODS.get(cfg.sizing_method)
+    if method is None:
+        raise ValueError(
+            f"unknown sizing_method {cfg.sizing_method!r}; expected one of {sorted(_METHODS)}"
+        )
+    return method(signal, cfg)

--- a/stockpredictor/strategy.py
+++ b/stockpredictor/strategy.py
@@ -31,6 +31,7 @@ from .signals import Signal, SignalFn
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .portfolio import WeightFn
+    from .sentiment import SentimentResult
 
 logger = logging.getLogger("stockpredictor.strategy")
 
@@ -79,6 +80,25 @@ def make_weight_fn(
         return float(min(max(fraction, 0.0), cfg.max_weight))
 
     return _fn
+
+
+def build_weight_fn(
+    cfg: config.AppConfig,
+    *,
+    sentiment: SentimentResult | None = None,
+    signal_fn: SignalFn | None = None,
+) -> WeightFn:
+    """Assemble the production ``WeightFn``: forecast signal → gate → cfg-selected sizing.
+
+    The sizing method (``vol`` | ``kelly``) is chosen inside ``sizing.size_position``
+    from ``cfg.sizing_method`` each call, so it stays a logged, swappable variant.
+    ``signal_fn`` is overridable for tests; by default it is the point-in-time
+    forecast signal from ``signals.make_signal_fn``.
+    """
+    from . import signals, sizing
+
+    signal_fn = signal_fn or signals.make_signal_fn(cfg, sentiment=sentiment)
+    return make_weight_fn(signal_fn, sizing_fn=sizing.size_position)
 
 
 def variant_id(cfg: config.AppConfig) -> str:

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,98 @@
+"""Tests for position sizing: vol-targeting, fractional Kelly, and edge cases."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from stockpredictor import config, sizing
+from stockpredictor.signals import Signal
+
+
+def _sig(mu: float, sigma: float = 0.30) -> Signal:
+    return Signal(
+        expected_return=mu, uncertainty=sigma, confidence=1.0, as_of=pd.Timestamp("2025-01-31")
+    )
+
+
+# --- Volatility targeting ----------------------------------------------------
+def test_vol_target_hits_target_over_forecast_vol():
+    cfg = config.AppConfig(target_vol=0.10, max_weight=1.0)
+    s = _sig(mu=0.05, sigma=0.10)
+    forecast_vol = 0.10 * math.sqrt(config.PERIODS_PER_YEAR)
+    assert sizing.vol_target_weight(s, cfg) == pytest.approx(0.10 / forecast_vol)
+
+
+def test_vol_target_caps_at_max_weight_for_calm_asset():
+    cfg = config.AppConfig(target_vol=0.10, max_weight=1.0)
+    # A near-zero-vol asset would imply an enormous position -> capped at max_weight.
+    assert sizing.vol_target_weight(_sig(mu=0.05, sigma=1e-9), cfg) == cfg.max_weight
+
+
+def test_vol_target_respects_lower_max_weight():
+    cfg = config.AppConfig(target_vol=0.50, max_weight=0.6)
+    assert sizing.vol_target_weight(_sig(mu=0.05, sigma=0.05), cfg) == 0.6
+
+
+# --- Fractional Kelly --------------------------------------------------------
+def test_fractional_kelly_is_lambda_times_full_kelly():
+    cfg = config.AppConfig(kelly_fraction=0.25, max_weight=1.0)
+    s = _sig(mu=0.05, sigma=0.30)
+    excess = s.expected_return - config.periodic_rate(cfg.rf_annual)
+    full_kelly = excess / s.uncertainty**2
+    frac = sizing.kelly_weight(s, cfg)
+    assert frac == pytest.approx(0.25 * full_kelly)
+    assert frac < full_kelly  # fractional NEVER exceeds full Kelly
+
+
+def test_kelly_caps_at_max_weight():
+    cfg = config.AppConfig(kelly_fraction=0.25, max_weight=1.0)
+    # Large edge / small vol -> raw Kelly >> 1, clipped to the cap.
+    assert sizing.kelly_weight(_sig(mu=0.20, sigma=0.05), cfg) == cfg.max_weight
+
+
+def test_kelly_sigma_underflow_is_capped_not_divide_by_zero():
+    cfg = config.AppConfig(max_weight=1.0)
+    # σ so small that σ² underflows to exactly 0.0 -> guard returns the cap.
+    assert sizing.kelly_weight(_sig(mu=0.05, sigma=1e-200), cfg) == cfg.max_weight
+
+
+# --- Shared long-only / excess guards ----------------------------------------
+@pytest.mark.parametrize("method", [sizing.vol_target_weight, sizing.kelly_weight])
+def test_non_positive_return_gives_zero(method):
+    cfg = config.AppConfig()
+    assert method(_sig(mu=-0.10), cfg) == 0.0
+    assert method(_sig(mu=0.0), cfg) == 0.0
+
+
+@pytest.mark.parametrize("method", [sizing.vol_target_weight, sizing.kelly_weight])
+def test_positive_but_below_risk_free_gives_zero(method):
+    """μ above 0 but below the RF rate has no *excess* edge -> weight 0."""
+    cfg = config.AppConfig(rf_annual=0.04)
+    rf_period = config.periodic_rate(cfg.rf_annual)
+    assert method(_sig(mu=rf_period * 0.5), cfg) == 0.0
+
+
+@pytest.mark.parametrize("method", [sizing.vol_target_weight, sizing.kelly_weight])
+def test_sizing_never_negative(method):
+    cfg = config.AppConfig()
+    for mu in (-0.5, -0.01, 0.0, 0.01, 0.2):
+        assert method(_sig(mu), cfg) >= 0.0
+
+
+# --- Dispatcher --------------------------------------------------------------
+def test_size_position_dispatches_on_config():
+    s = _sig(mu=0.05, sigma=0.30)
+    vol_cfg = config.AppConfig(sizing_method="vol")
+    kelly_cfg = config.AppConfig(sizing_method="kelly")
+    assert sizing.size_position(s, vol_cfg) == sizing.vol_target_weight(s, vol_cfg)
+    assert sizing.size_position(s, kelly_cfg) == sizing.kelly_weight(s, kelly_cfg)
+    # The two methods generally disagree on magnitude for the same signal.
+    assert sizing.size_position(s, vol_cfg) != sizing.size_position(s, kelly_cfg)
+
+
+def test_size_position_rejects_unknown_method():
+    with pytest.raises(ValueError):
+        sizing.size_position(_sig(mu=0.05), config.AppConfig(sizing_method="bogus"))

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -87,6 +87,25 @@ def test_variant_id_is_deterministic_and_sensitive():
     assert a != c
 
 
+def test_build_weight_fn_applies_cfg_sizing():
+    """The assembled WeightFn runs gate → sizing: a bullish signal is sized < cap."""
+    from stockpredictor import sizing
+
+    cfg = config.AppConfig(sizing_method="vol", target_vol=0.10, max_weight=1.0)
+    bullish = lambda _h, _c: _signal(0.05, sigma=0.10)  # noqa: E731
+    wf = strategy.build_weight_fn(cfg, signal_fn=bullish)
+    expected = sizing.size_position(_signal(0.05, sigma=0.10), cfg)
+    assert wf(pd.Series([1.0, 2.0]), cfg) == pytest.approx(expected)
+    assert 0.0 < expected < cfg.max_weight  # genuinely sized, not just the cap
+
+
+def test_build_weight_fn_real_forecast_path_runs(monthly, cfg):
+    """Default path (real forecast signal + cfg sizing) drives the simulator cleanly."""
+    res = simulate(monthly, strategy.build_weight_fn(cfg), cfg)
+    assert (res.weights >= 0.0).all()
+    assert (res.weights <= cfg.max_weight + 1e-12).all()
+
+
 # --- Synthetic zero-edge / known-edge checks ---------------------------------
 def _momentum_signal(history: pd.Series, _cfg: config.AppConfig) -> Signal:
     """Naive predictor: next return ≈ last observed return. Only works if returns


### PR DESCRIPTION
## Phase 3 of the simulated betting / position-sizing layer

Builds on #22 (simulator) and #23 (signals + strategy). Converts a `Signal`'s conviction into a long-only position **fraction**, dropped into the `sizing_fn` seam Phase 2 left open. No rework of strategy/portfolio needed.

### What's here
- **`sizing.py`** (pure, no I/O):
  - **`vol_target_weight`** (default, more robust) — `weight = target_vol / forecast_vol`, capped at `max_weight`. Ignores the *magnitude* of μ, so noisy return estimates barely move the position; σ is annualized by √12 to compare against the annual target.
  - **`kelly_weight`** — `clip(λ · μ_excess / σ², 0, max_weight)`, **λ default 0.25**. Full Kelly is *never* the default (with estimated μ/σ it over-bets and courts ruinous drawdowns) — documented in the module.
  - Both take μ as **excess over RF** (§5), are **long-only** (non-positive excess → 0, never negative), and **guard σ→0** (cap, not divide-by-zero).
  - `size_position` dispatches on `cfg.sizing_method` (`vol` | `kelly`) so the choice stays a logged, swappable variant.
- **`strategy.build_weight_fn`** — assembles `forecast signal → gate → cfg-selected sizing` into the production `WeightFn` the simulator drives.

### Edge-case tests (brief §7)
- σ→0 ⇒ capped at `max_weight` (both methods), incl. a σ²-underflow guard that returns the cap instead of dividing by zero.
- μ ≤ 0 ⇒ weight 0; μ positive **but below RF** ⇒ 0 (the excess convention).
- Fractional Kelly == λ·full Kelly and **never exceeds full Kelly**.
- Long-only never negative; vol-target hits `target/forecast_vol` and respects a lower `max_weight`.
- Dispatcher selects the method and rejects unknown names; `build_weight_fn` applies sizing and the real-forecast path drives the sim with weights in `[0, max_weight]`.

`ruff` + `ruff format --check` + `mypy stockpredictor` clean; full suite **147 passing**; coverage **90.7%** (`sizing.py` & `strategy.py` 100%).

### Deferred → Phase 4 (final)
Full evaluation metric set (CAGR, Sharpe, Sortino, max drawdown, turnover, hit rate, excess-over-BH/RF, returns-space MASE analog) + the plain-language **scorecard**, `store.py` run-logging with `variant_id` + the multiple-testing warning + held-out slice, CLI `--simulate` / `--sizing` / `--rf-rate` / cost flags, dashboard tab, and the README section.

> ⚠️ Educational demo — not financial advice. Paper trading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)