### PR TITLE
ci: target mypy at 3.12 to fix numpy stub type-check failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ ignore = ["E501"]  # line length handled by the formatter
 "tests/**" = ["S101"]
 
 [tool.mypy]
-python_version = "3.9"
+# Target 3.12: mypy >=1.19 dropped 3.9 as a check target, and numpy's stubs now
+# use PEP 695 `type` statements that mypy only accepts when targeting >=3.12.
+# Runtime 3.9 support is still verified by the pytest matrix in CI.
+python_version = "3.12"
 ignore_missing_imports = true
 warn_unused_ignores = true
 no_implicit_optional = true


### PR DESCRIPTION
## Problem
`main` CI is red on the `test (3.12)` job. Two already-merged dependency bumps collide:

- mypy `>=1.19.1` (#37) dropped Python 3.9 as a valid type-check target.
- numpy `>=2.0.2` (#36) pulls stubs that use PEP 695 `type` statements, which mypy only accepts when targeting `>=3.12`.

With `[tool.mypy] python_version = "3.9"`, the 3.12 job fails:
```
numpy/__init__.pyi: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

## Fix
Set the mypy target to `3.12`. This is the minimum that satisfies the numpy stubs; lower targets (3.10/3.11) hit the same error.

Runtime Python 3.9 support is unchanged and still verified by the pytest matrix (`3.9`, `3.11`, `3.12`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)