### PR TITLE
chore: drop Python 3.9 support (EOL) — require >=3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CI](https://github.com/RealMaxPower/StockPredictorWithSentiment/actions/workflows/ci.yml/badge.svg)](https://github.com/RealMaxPower/StockPredictorWithSentiment/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Python](https://img.shields.io/badge/python-3.9%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![Status](https://img.shields.io/badge/status-v0.2%20%C2%B7%20educational%20demo-orange.svg)](#)
 
 This tool forecasts the next 12 months of a stock's price from its history **with
@@ -21,7 +21,7 @@ question: *would trading on this forecast have made money after costs?* (Usually
 > uncertainty band seriously." This tool is for learning, not trading.
 
 **At a glance:** v0.2 · 16-module Python package · ~120 tests (network mocked) ·
-CI on 3.9 / 3.11 / 3.12 · CLI + Streamlit dashboard · forecasts run with **no API key**.
+CI on 3.10 / 3.11 / 3.12 · CLI + Streamlit dashboard · forecasts run with **no API key**.
 
 ---
 
@@ -262,7 +262,7 @@ ruff check . && ruff format --check .
 mypy stockpredictor
 ```
 
-CI runs lint + types + tests across Python 3.9/3.11/3.12, plus a `pip-audit` job.
+CI runs lint + types + tests across Python 3.10/3.11/3.12, plus a `pip-audit` job.
 
 `python3 update_readme_date.py` updates the example command's `--end` to the most
 recent Friday (hardened against a missing/unwritable README and silent no-ops).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "stockpredictor"
 version = "0.2.0"
 description = "Historical price forecasting with prediction intervals and news-sentiment context."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }
 authors = [{ name = "Marshall Cahill", email = "contactme@marshallcahill.com" }]
 keywords = ["stocks", "forecasting", "sentiment", "holt-winters", "newsapi"]
@@ -58,9 +58,9 @@ ignore = ["E501"]  # line length handled by the formatter
 "tests/**" = ["S101"]
 
 [tool.mypy]
-# Target 3.12: mypy >=1.19 dropped 3.9 as a check target, and numpy's stubs now
-# use PEP 695 `type` statements that mypy only accepts when targeting >=3.12.
-# Runtime 3.9 support is still verified by the pytest matrix in CI.
+# Target 3.12: numpy's stubs use PEP 695 `type` statements that mypy only
+# accepts when targeting >=3.12, so this sits above our 3.10 floor. Runtime
+# compatibility across 3.10-3.12 is verified by the pytest matrix in CI.
 python_version = "3.12"
 ignore_missing_imports = true
 warn_unused_ignores = true


### PR DESCRIPTION
## Why
Python 3.9 reached end-of-life in **October 2025**, and the dependency stack has moved past it. Current releases of core deps now require Python ≥3.10:

- `numpy` ≥2.1 → requires-python ≥3.10
- `matplotlib` ≥3.10 → requires-python ≥3.10
- `pip-audit` ≥2.10 → requires-python ≥3.10

The `test (3.9)` CI job can no longer install current versions, which is blocking the numpy/matplotlib/pip-audit Dependabot bumps (#44, #45, #46).

## Changes
- `requires-python`: `>=3.9` → `>=3.10`
- CI matrix: `3.9` → `3.10` (retains `3.10` / `3.11` / `3.12`)
- README badge + text updated to `3.10 / 3.11 / 3.12`
- Refreshed the `[tool.mypy]` comment (target stays `3.12` for numpy's PEP 695 stubs; now sits above the 3.10 floor)

## Follow-up
Once this merges, #44 / #45 / #46 can be rebased and will pass, and #43 (transformers 5.x) / #47 (torch) can be evaluated on their own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)